### PR TITLE
Branching selectors efficiently

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,40 +45,6 @@ button .class_1  { color: yellow; }
 button.concatenated_class { padding: 10px; }
 ```
 
-#### Functions
-
-```elixir
-
-@fn lighten(color, percentage) {
-    {:ok, %CSSEx.HSLA{l: %CSSEx.Unit{value: l} = l_unit} = hsla} = 
-                                                       CSSEx.HSLA.new_hsla(color)
-
-    {percentage, _} = Float.parse(percentage)
-
-    new_l = 
-      case l + percentage do
-         n_l when n_l <= 100 and n_l >= 0 -> n_l
-	 n_l when n_l > 100 -> 100
-	 n_l when n_l < 0 -> 0
-      end
-
-    {:ok, %CSSEx.HSLA{hsla | l: %CSSEx.Unit{l_unit | value: new_l}} |> to_string}
-};
-
-@!red red;
-.test{color: @fn::lighten(<$red$>, 10)}
-.test{color: @fn::lighten(#fdf, 10);}
-```
-
-##### into
-
-```css
-.test {
-  color: hsla(0,100%,60%,1.0);
-  color: hsla(300,7%,15%,1.0);
-}
-```
-
 #### Variables
 
 ```css
@@ -184,6 +150,41 @@ div { font-size: 20px; }
 
 These scope ruling might still be changed regarding the scoped workings and the undefined versions. Variables are inserted always using the interpolation markers, `<$ variable_name $>`.
 
+
+#### Functions
+
+```elixir
+
+@fn lighten(color, percentage) {
+    {:ok, %CSSEx.HSLA{l: %CSSEx.Unit{value: l} = l_unit} = hsla} = 
+                                                       CSSEx.HSLA.new_hsla(color)
+
+    {percentage, _} = Float.parse(percentage)
+
+    new_l = 
+      case l + percentage do
+         n_l when n_l <= 100 and n_l >= 0 -> n_l
+	 n_l when n_l > 100 -> 100
+	 n_l when n_l < 0 -> 0
+      end
+
+    {:ok, %CSSEx.HSLA{hsla | l: %CSSEx.Unit{l_unit | value: new_l}} |> to_string}
+};
+
+@!red red;
+.test{color: @fn::lighten(<$red$>, 10)}
+.test{color: @fn::lighten(#fdf, 10);}
+```
+
+##### into
+
+```css
+.test {
+  color: hsla(0,100%,60%,1.0);
+  color: hsla(300,7%,15%,1.0);
+}
+```
+
 #### Assigns
 
 Assigns are as if variables and they have the same options and scoping as that of variables, but instead of being `@!`, `@*!`, `@()` and `@?`, they're identified by `%!`, `%()` and `%?`.
@@ -220,6 +221,10 @@ An EEx block has to return either a binary (a String.t) or an iodata list. When 
 <div id="caveats"></div>
 
 ### Caveats
+
+Some details like scoping rules and what scope identifiers will be available is still open ended.
+
+Postfixing operators with the & concatenator is still not working and I'm still considering if introducing them is really worthwile. 
 
 Due to the way it parses and builds output the final CSS files avoid a lot of repetition. It doesn't parse and insert the parsed result in place, instead it builds a table of selectors -> attributes and while parsing rules adds them to that selector. The order of the attributes for a selector is guaranteed, but the final layout of the selectors themselves is not.
 
@@ -355,6 +360,8 @@ In terms of speed, although I haven't done extensive benchmarking as I want firs
 
 ## Roadmap
 
+- Define the scoping rules and possibilities for variables, assigns, and functions
+- Finalize the `&` usage when placed as postfix
 - Basic functions such as: `lighten`, `darken`, etc.;
 - Mix task for parsing CSSEx files
 

--- a/lib/helpers/error.ex
+++ b/lib/helpers/error.ex
@@ -1,10 +1,14 @@
 defmodule CSSEx.Helpers.Error do
+
+  # this means that the error is being bubbled up
+  def error_msg(%{valid?: false, error: error}), do: error
+  
   def error_msg({:mismatched, char}), do: "mismatched #{char}"
 
   def error_msg({:not_declared, :var, val}), do: "variable #{val} was not declared"
   def error_msg({:not_declared, :val, val}), do: "assign #{val} was not declared"
   def error_msg({:not_declared, :function, name}), do: "function #{name} was not declared"
-
+  def error_msg({:unexpected, string}), do: "unexpected token: #{string}"
   def error_msg({:cyclic_reference, path, _file_list}),
     do: "cyclic reference, #{path} won't be able to be parsed"
 

--- a/lib/helpers/shared.ex
+++ b/lib/helpers/shared.ex
@@ -10,6 +10,33 @@ defmodule CSSEx.Helpers.Shared do
   def generate_prefix(%{current_chain: cc, prefix: nil}), do: cc
   def generate_prefix(%{current_chain: cc, prefix: prefix}), do: prefix ++ cc
 
+  # we only have one element but we do have a prefix, set the split chain to the prefix and reset the current_chain
+  def remove_last_from_chain(%{current_chain: [_], prefix: prefix} = data) when not is_nil(prefix), do: %{data | current_chain: [], split_chain: [prefix]}
+  
+  # we only have one element so reset both chains
+  def remove_last_from_chain(%{current_chain: [_]} = data),
+    do: %{data | current_chain: [], split_chain: []}
+
+  # we have more than one
+  def remove_last_from_chain(%{current_chain: [_|_] = chain, prefix: prefix} = data) do
+    [_ | new_chain] = :lists.reverse(chain)
+    new_chain = :lists.reverse(new_chain)
+
+    %{data | current_chain: new_chain, split_chain: split_chains(new_chain, prefix)}
+  end
+
+  def add_selector_to_chain(%{current_chain: cc, prefix: prefix} = data, selector) do
+    new_chain = [selector | :lists.reverse(cc)] |> :lists.reverse
+    new_split =
+      case new_chain do
+	[_] when is_nil(prefix) -> [new_chain]
+	[_] -> [prefix ++ new_chain]
+	_ -> split_chains(new_chain, prefix)
+      end
+
+    %{data | current_chain: new_chain, split_chain: new_split}
+  end
+
   def ampersand_join(initial), do: ampersand_join(initial, [])
 
   def ampersand_join([head, <<"&", rem::binary>> | t], acc),
@@ -19,30 +46,29 @@ defmodule CSSEx.Helpers.Shared do
 
   def ampersand_join([], acc), do: :lists.flatten(acc)
 
-  def split_chains(initial), do: split_chains(initial, [])
+  def split_chains(initial, prefix), do: split_chains(initial, [], prefix)
 
-  def split_chains([], acc),
-    do:
-      Enum.map(acc, fn
-        chain when is_list(chain) ->
-          chain
-          |> :lists.flatten()
-          |> ampersand_join()
-
-        chain ->
-          [chain]
-      end)
-
-  def split_chains([head | t], []) do
+  def split_chains([], acc, prefix) do
+    Enum.map(acc, fn
+      chain when is_list(chain) -> 
+	final =  :lists.flatten(chain)
+      if(prefix, do: prefix ++ final, else: final)
+      |> ampersand_join()
+      
+      chain -> if(prefix, do: [prefix ++ [chain]], else: [chain])
+    end)
+  end
+      
+  def split_chains([head | t], [], prefix) do
     splits =
       head
       |> String.split(",")
       |> Enum.map(fn el -> String.trim(el) end)
 
-    split_chains(t, splits)
+    split_chains(t, splits, prefix)
   end
 
-  def split_chains([head | t], acc) do
+  def split_chains([head | t], acc, prefix) do
     splits =
       head
       |> String.split(",")
@@ -55,6 +81,6 @@ defmodule CSSEx.Helpers.Shared do
         end)
       end)
 
-    split_chains(t, new_acc)
+    split_chains(t, new_acc, prefix)
   end
 end

--- a/test/error_test.exs
+++ b/test/error_test.exs
@@ -8,7 +8,7 @@ defmodule CSSEx.Error.Test do
     div { color: red; }
     """
 
-    assert {:error, {_, %{error: error}}} = Parser.parse(css)
+    assert {:error, %{error: error}} = Parser.parse(css)
     assert error =~ "invalid :assign declaration at l:1 col:1 to\" :: l:3 c:0"
   end
 
@@ -19,7 +19,7 @@ defmodule CSSEx.Error.Test do
     }
     """
 
-    assert {:error, {_, %{error: error}}} = Parser.parse(css_1)
+    assert {:error, %{error: error}} = Parser.parse(css_1)
     assert error =~ "unable to find terminator for \\\" at l:1 col:14 to\" :: l:4 c:0"
 
     css_2 = """
@@ -28,7 +28,7 @@ defmodule CSSEx.Error.Test do
     }
     """
 
-    assert {:error, {_, %{error: error}}} = Parser.parse(css_2)
+    assert {:error, %{error: error}} = Parser.parse(css_2)
     assert error =~ "unable to find terminator for [ at l:1 col:3 to\" :: l:4 c:0"
   end
 
@@ -41,7 +41,7 @@ defmodule CSSEx.Error.Test do
     end
     """
 
-    assert {:error, {_, %{error: error}}} = Parser.parse(css)
+    assert {:error, %{error: error}} = Parser.parse(css)
     assert error =~ "invalid :eex declaration at l:2 col:0 to\" :: l:6 c:0"
   end
 
@@ -51,7 +51,27 @@ defmodule CSSEx.Error.Test do
     @!test 2;
     """
 
-    assert {:error, {_, %{error: error}}} = Parser.parse(css)
+    assert {:error, %{error: error}} = Parser.parse(css)
     assert error =~ "invalid :variable declaration at l:1 col:1 to\" :: l:1 c:6"
+  end
+
+  test "nested media bug #8 should provide an error" do
+    assert {:error, %{error: error}} = Parser.parse(
+    """
+    @media only screen {
+      header nav a {
+        display: block;
+    	color: white;
+    	text-decoration: none;
+    
+        a:focus, a:hover {
+          color: #000;
+    	};
+      }
+    }
+    """
+    )
+
+    assert error =~ "unexpected token: ;  \" :: l:10 c:0"
   end
 end

--- a/test/files/finals/test_1.css
+++ b/test/files/finals/test_1.css
@@ -1,1 +1,0 @@
-.test_2{background-color:#ffffff;color:#000000;}.write{color:red;}.test_1{background-color:#000000;color:#ffffff;}div{color:black;color:white;background-color:red;}div:hover{cursor:pointer;background-color:green;color:purple;}

--- a/test/files/originals/test_1.cssex
+++ b/test/files/originals/test_1.cssex
@@ -30,4 +30,4 @@ div {
     color: <$primary$>
   }
 }
- .write{color:red;}
+ 

--- a/test/nesting_test.exs
+++ b/test/nesting_test.exs
@@ -46,15 +46,13 @@ defmodule CSSEx.Nesting.Test do
     assert parsed =~ ".div_1.div_3_b{margin:10px;}"
 
     # this needs to be better 
-    assert parsed =~ ".box-1{color:magenta;}"
+    assert parsed =~ ".box-1, .box-2, .box-3{color:magenta;}"
     assert parsed =~ ".box-1.box-4{height:50px;}"
     assert parsed =~ ".box-1 .box-5{height:50px;}"
 
-    assert parsed =~ ".box-2{color:magenta;}"
     assert parsed =~ ".box-2.box-4{height:50px;}"
     assert parsed =~ ".box-2 .box-5{height:50px;}"
 
-    assert parsed =~ ".box-3{color:magenta;}"
     assert parsed =~ ".box-3.box-4{height:50px;}"
     assert parsed =~ ".box-3 .box-5{height:50px;}"
   end


### PR DESCRIPTION
- Make the branching of comma-separated selectors more efficient by only producing it when transitioning between blocks
- Add error when parsing semi-colons outside an attribute or valid element
- Change readme and roadmap