### PR TITLE
Tasks

### DIFF
--- a/lib/cssex.ex
+++ b/lib/cssex.ex
@@ -33,12 +33,15 @@ defmodule CSSEx do
         :entry_points ->
           new_entries =
             Enum.map(v, fn {orig, final} ->
-	      case dir do
-		nil -> {orig, final}
-		_ -> 
-		  {Path.join([dir, orig]), Path.join([dir, final])}
-	      end
+              case dir do
+                nil ->
+                  {orig, final}
+
+                _ ->
+                  {Path.join([dir, orig]), Path.join([dir, final])}
+              end
             end)
+
           struct(acc, [{k, new_entries}])
 
         _ ->

--- a/lib/cssex.ex
+++ b/lib/cssex.ex
@@ -33,9 +33,12 @@ defmodule CSSEx do
         :entry_points ->
           new_entries =
             Enum.map(v, fn {orig, final} ->
-              {Path.join([dir, orig]), Path.join([dir, final])}
+	      case dir do
+		nil -> {orig, final}
+		_ -> 
+		  {Path.join([dir, orig]), Path.join([dir, final])}
+	      end
             end)
-
           struct(acc, [{k, new_entries}])
 
         _ ->
@@ -306,8 +309,8 @@ defmodule CSSEx do
   end
 
   # TODO check use cases with expand, perhaps it's not warranted?
-  defp assemble_path(<<"/", _::binary>> = path, _cwd), do: Path.expand(path)
+  def assemble_path(<<"/", _::binary>> = path, _cwd), do: Path.expand(path)
 
-  defp assemble_path(path, cwd),
+  def assemble_path(path, cwd),
     do: Path.join([cwd, path]) |> Path.expand()
 end

--- a/lib/mix/tasks/css.parser.ex
+++ b/lib/mix/tasks/css.parser.ex
@@ -1,140 +1,129 @@
-defmodule Mix.Tasks.CSS.Parser do
+defmodule Mix.Tasks.Cssex.Parser do
+  use Mix.Task
+  require Logger
+  
   @moduledoc """
-  The entry point to the parser task. It takes a filename path and it tries to parse it into CSS, no additional options available as of now.
+  Task to parse cssex files into css files.
+  You can use two types of flags, --e (and additionally --a) or --c.
 
-  The target file can use any of elixir's templating capabilities to produce the intermediate version before CSS expansion. It has access only to scoped variables declared in the cssex tree, available as assigns. 
+  For the --e flag you use any number of
 
-  This means two things happen, if a cssex file imports other cssex files the imported cssex files while being processed will be able to use variables declared previously in the current scope and any variable declaration in them will shadow any previously declared ones until the current scope ends.
+  --e path/to_cssex/file.cssex=path/to_css/output.css
 
-  There's 6 kinds of variables that can be declared:
+  And if you want those paths to be relative to some application you can pass it with --m
 
-    @!variable value;
-   
-  This is a normal variable that can shadow any other previously declared until the root original scope runs to its end.
+  --a myapp_web
 
+  arguments to specify each entry and its output file, or a single path to the cssex where the output file will be in the same directory, with the same file name but the extension css added to it
 
-    @()variable value;
+  --e path/to_cssex/file.cssex
 
-  This is a normal variable that will only be set in the current scope of cssex file being parsed. Once the file ends it's value is returned to what it was on the outside scope.
+  The --c flag is used to indicate an entry in the config of the application, in order to read the entry points from there
 
-
-    @?variable value;
-
-  This is a conditional variable that will only be set if a same named variable isn't available in the current scope. It's limited to the current cssex file being parsed.
-
-  These previous three declarations' values are as is, string representations to be injected in the final CSS, you shouldn't use quotes around the values, e.g.:
-
-    @!test 16px;
-    
-  Will create a @!test variable usable throughout the following cssex file and imported files inside it through the syntax @$$test, including inside <%= eex blocks %> declared in any of the outer or child templates.
-
-
-  Placing a * after the @ character creates as well a normal css variable, this css variable due to CSS scoping has different nuances, but basically will, if declared at the top level of a parsing step (not inside any CSS identifier), create a variable in the :root element, otherwise, it will create a variable inside whatever CSS definition it's in, e.g.:
-
-  @*!color red;
-
-  .sample-div {
-     @*!color blue;
-     color: @$$color;
-  }
-
-  p { color: @$$color; }
-
-  Will generate:
-
-    :root {
-       --color: red;
-    }
-
-    .sample-div {
-       --color: blue;
-       color: blue;
-    }
-
-    p { color: blue; }
-
-  But on the other hand:
-
-    @*!color red;
-
-    .sample-div {
-       @*()color blue;
-       color: @$$color;
-    }
-
-    p { color: @$$color; }
-
-  Will generate:
-
-    :root {
-       --color: red;
-    }
-
-    .sample-div {
-       --color: blue;
-       color: blue;
-    }
-
-    p { color: red; }
-
-  Lastly
-
-    %!variable %{
-      elixir_map: binary_string
-    };
-    %()variable same;
-    %?variable same;
-
-  This is exactly the same as before but these variables are only available inside eex templates and can hold any elixir term, where each key has a value that is either another map or a binary_string. The values when strings needs to be delimited by quotes as normal elixir strings. To use them in an eex block you would do:
-
-    %::variable_name
-
-  The termination of an assign has to always be ; followed by a newline indicator.
-
-  An example would be:
-
-    %!map_colors %{color_1: "red", color_2: "blue"};
-
-    button {
-      <%= for {color_key, color} <- %::map_colors do %>
-        \"""
-  &.\#{color_key} {
-    color: \#{color};
-    &:hover {
-      color: lighten(\#{color}, 10%);
-    }
-  }
-  \"""
-      <%= end %>
-    }
-
-
-  Which would result in an intermediate expression of:
-
-    button {
-       &.color_1 { 
-         color: red;
-  &:hover {
-    color: lighten(red, 10%);
-  }
-       }
-       &.color_2 { 
-         color: blue;
-  &:hover {
-    color: lighten(blue, 10%);
-  }
-       }
-    }
-
-  When the eex compilation was done, and finally end up as:
-
-    button.color_1 { color: red;}
-    button.color_1:hover { color: #sfjsjh; }
-    button.color_2 { color: blue;}
-    button.color_2:hover { color: #tkgigd; }
-
-  When the final cssex parsing was done.
-
-  Using @$$variable name inside a eex template does nothing, those variables will be replaced only after the eex evaluation. You can run any code inside an eex block, but it must return a String.t, or list of binaries, as those will be written as String.t(s) into the file before the final cssex expansion.
+  --c myapp_web
   """
+  def run([]), do: error("either specify the file paths with --e cssex/file.cssex=output/file.css, and/or the  or a module from where to load a CSSEx config, with --c myapp_web", 64)
+  
+  def run(["--c", app_string]) do
+    app = String.to_atom(app_string)
+    dir = Application.app_dir(app)
+    env = Application.get_env(app, CSSEx)
+
+    case not is_nil(env) && CSSEx.make_config(env, dir) do
+      %CSSEx{entry_points: [_|_]} = config -> do_run(config)
+      _ ->
+	error("loading default entry points for app: #{app}. The retrieved config was: #{env} - where instead it was expected a keyword list with an :entry_points entry specifying at least one file", 1)
+    end
+  end
+
+  def run(args) do
+    {options, _, _} = OptionParser.parse(args, strict: [e: :keep, a: :string])
+
+    
+    
+    {module, opts} = Keyword.pop_first(options, :a, false)
+
+    eps =
+      Enum.reduce(opts, [], fn({_, paths}, acc) ->
+	case String.split(paths, "=", trim: true) do
+	  [from, to] ->
+	    [{from, to} | acc]
+
+	  [from] ->
+	    [{from, String.replace(from, ".cssex", ".css")} | acc]
+	  _ ->
+	    error("invalid paths #{paths}", 64)
+	end
+      end)
+
+    dir = case module do
+	    false -> nil
+	    _ ->
+	      String.to_atom(module)
+	      |> Application.app_dir()
+	  end
+
+    case length(eps) > 0 do
+      true ->
+	CSSEx.make_config([entry_points: eps], dir)
+	|> do_run()
+      false ->
+	error("no paths given", 64)
+    end
+  end
+
+  defp do_run(%CSSEx{entry_points: eps}) do
+    cwd = File.cwd!()
+    tasks =
+      for {path, final} <- eps do
+	expanded_base = CSSEx.assemble_path(path, cwd)
+	expanded_final = CSSEx.assemble_path(final, cwd)
+	
+	Task.async(fn ->
+	  result = CSSEx.Parser.parse_file(Path.dirname(expanded_base), Path.basename(expanded_base))
+	  {result, expanded_base, expanded_final}
+	end)
+	
+      end
+
+    processed = Task.yield_many(tasks, 60_000)
+
+    Enum.map(processed, fn
+      ({_, {:ok, {{:ok, %{valid?: true}, content}, base, final}}}) ->
+	try_write(base, final, content)
+      ({_, {:ok, {{:error, %{error: error}}, _, _}}}) ->
+	error(error)
+      error ->
+	error(error)
+    end)
+
+    case Enum.all?(processed, fn
+	  ({_, {task_res, {{processed_res, _, _}, _, _}}}) -> task_res == :ok and processed_res == :ok
+	  (_) -> false
+	end
+	) do
+      true -> :ok
+      _ -> exit({:shutdown, 1})
+    end
+  end
+
+  defp try_write(base, path, content) do
+    with(
+      :ok <- File.mkdir_p(Path.dirname(path)),
+      :ok <- File.write(path, content, [:write])
+    ) do
+      ok(base, path)
+    else
+      error ->
+	error(error)
+    end
+  end
+
+  defp error(msg, code) do
+    error(msg)
+    exit({:shutdown, code})
+  end
+  
+  defp error(msg), do: Logger.error("ERROR :: #{inspect msg}")
+  defp ok(base, file), do: Logger.info("PROCESSED :: #{base} into #{inspect file}")
 end

--- a/lib/mix/tasks/css.parser.ex
+++ b/lib/mix/tasks/css.parser.ex
@@ -25,7 +25,7 @@ defmodule Mix.Tasks.Cssex.Parser do
   def run([]),
     do:
       error(
-        "either specify the file paths with --e cssex/file.cssex=output/file.css, and/or the  or a module from where to load a CSSEx config, with --c myapp_web",
+        "either specify the file paths with --e cssex/file.cssex=output/file.css, and/or the --a application flag or a module from where to load a CSSEx config, with --c myapp_web",
         64
       )
 

--- a/lib/mix/tasks/css.parser.ex
+++ b/lib/mix/tasks/css.parser.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Tasks.Cssex.Parser do
   use Mix.Task
   require Logger
-  
+
   @moduledoc """
   Task to parse cssex files into css files.
   You can use two types of flags, --e (and additionally --a) or --c.
@@ -22,86 +22,105 @@ defmodule Mix.Tasks.Cssex.Parser do
 
   --c myapp_web
   """
-  def run([]), do: error("either specify the file paths with --e cssex/file.cssex=output/file.css, and/or the  or a module from where to load a CSSEx config, with --c myapp_web", 64)
-  
+  def run([]),
+    do:
+      error(
+        "either specify the file paths with --e cssex/file.cssex=output/file.css, and/or the  or a module from where to load a CSSEx config, with --c myapp_web",
+        64
+      )
+
   def run(["--c", app_string]) do
     app = String.to_atom(app_string)
     dir = Application.app_dir(app)
     env = Application.get_env(app, CSSEx)
 
     case not is_nil(env) && CSSEx.make_config(env, dir) do
-      %CSSEx{entry_points: [_|_]} = config -> do_run(config)
+      %CSSEx{entry_points: [_ | _]} = config ->
+        do_run(config)
+
       _ ->
-	error("loading default entry points for app: #{app}. The retrieved config was: #{env} - where instead it was expected a keyword list with an :entry_points entry specifying at least one file", 1)
+        error(
+          "loading default entry points for app: #{app}. The retrieved config was: #{env} - where instead it was expected a keyword list with an :entry_points entry specifying at least one file",
+          1
+        )
     end
   end
 
   def run(args) do
     {options, _, _} = OptionParser.parse(args, strict: [e: :keep, a: :string])
 
-    
-    
     {module, opts} = Keyword.pop_first(options, :a, false)
 
     eps =
-      Enum.reduce(opts, [], fn({_, paths}, acc) ->
-	case String.split(paths, "=", trim: true) do
-	  [from, to] ->
-	    [{from, to} | acc]
+      Enum.reduce(opts, [], fn {_, paths}, acc ->
+        case String.split(paths, "=", trim: true) do
+          [from, to] ->
+            [{from, to} | acc]
 
-	  [from] ->
-	    [{from, String.replace(from, ".cssex", ".css")} | acc]
-	  _ ->
-	    error("invalid paths #{paths}", 64)
-	end
+          [from] ->
+            [{from, String.replace(from, ".cssex", ".css")} | acc]
+
+          _ ->
+            error("invalid paths #{paths}", 64)
+        end
       end)
 
-    dir = case module do
-	    false -> nil
-	    _ ->
-	      String.to_atom(module)
-	      |> Application.app_dir()
-	  end
+    dir =
+      case module do
+        false ->
+          nil
+
+        _ ->
+          String.to_atom(module)
+          |> Application.app_dir()
+      end
 
     case length(eps) > 0 do
       true ->
-	CSSEx.make_config([entry_points: eps], dir)
-	|> do_run()
+        CSSEx.make_config([entry_points: eps], dir)
+        |> do_run()
+
       false ->
-	error("no paths given", 64)
+        error("no paths given", 64)
     end
   end
 
   defp do_run(%CSSEx{entry_points: eps}) do
     cwd = File.cwd!()
+
     tasks =
       for {path, final} <- eps do
-	expanded_base = CSSEx.assemble_path(path, cwd)
-	expanded_final = CSSEx.assemble_path(final, cwd)
-	
-	Task.async(fn ->
-	  result = CSSEx.Parser.parse_file(Path.dirname(expanded_base), Path.basename(expanded_base))
-	  {result, expanded_base, expanded_final}
-	end)
-	
+        expanded_base = CSSEx.assemble_path(path, cwd)
+        expanded_final = CSSEx.assemble_path(final, cwd)
+
+        Task.async(fn ->
+          result =
+            CSSEx.Parser.parse_file(Path.dirname(expanded_base), Path.basename(expanded_base))
+
+          {result, expanded_base, expanded_final}
+        end)
       end
 
     processed = Task.yield_many(tasks, 60_000)
 
     Enum.map(processed, fn
-      ({_, {:ok, {{:ok, %{valid?: true}, content}, base, final}}}) ->
-	try_write(base, final, content)
-      ({_, {:ok, {{:error, %{error: error}}, _, _}}}) ->
-	error(error)
+      {_, {:ok, {{:ok, %{valid?: true}, content}, base, final}}} ->
+        try_write(base, final, content)
+
+      {_, {:ok, {{:error, %{error: error}}, _, _}}} ->
+        error(error)
+
       error ->
-	error(error)
+        error(error)
     end)
 
     case Enum.all?(processed, fn
-	  ({_, {task_res, {{processed_res, _, _}, _, _}}}) -> task_res == :ok and processed_res == :ok
-	  (_) -> false
-	end
-	) do
+           {_, {task_res, {{processed_res, _, _}, _, _}}} ->
+             task_res == :ok and processed_res == :ok
+
+           _ ->
+             false
+         end) do
       true -> :ok
       _ -> exit({:shutdown, 1})
     end
@@ -115,7 +134,7 @@ defmodule Mix.Tasks.Cssex.Parser do
       ok(base, path)
     else
       error ->
-	error(error)
+        error(error)
     end
   end
 
@@ -123,7 +142,7 @@ defmodule Mix.Tasks.Cssex.Parser do
     error(msg)
     exit({:shutdown, code})
   end
-  
-  defp error(msg), do: Logger.error("ERROR :: #{inspect msg}")
-  defp ok(base, file), do: Logger.info("PROCESSED :: #{base} into #{inspect file}")
+
+  defp error(msg), do: Logger.error("ERROR :: #{inspect(msg)}")
+  defp ok(base, file), do: Logger.info("PROCESSED :: #{base} into #{inspect(file)}")
 end

--- a/test/files/finals/test_1.css
+++ b/test/files/finals/test_1.css
@@ -1,0 +1,1 @@
+.test_2{background-color:#ffffff;color:#000000;}.write{color:red;}.test_1{background-color:#000000;color:#ffffff;}div{color:black;color:white;background-color:red;}div:hover{cursor:pointer;background-color:green;color:purple;}

--- a/test/files/originals/test_1.cssex
+++ b/test/files/originals/test_1.cssex
@@ -30,4 +30,4 @@ div {
     color: <$primary$>
   }
 }
- 
+ .write{color:red;}

--- a/test/files/task/finished/base.css
+++ b/test/files/task/finished/base.css
@@ -1,0 +1,1 @@
+div.test{color:red;}

--- a/test/files/task/finished/base_2.css
+++ b/test/files/task/finished/base_2.css
@@ -1,0 +1,1 @@
+div.test{color:blue;}

--- a/test/files/task/original.cssex
+++ b/test/files/task/original.cssex
@@ -1,0 +1,5 @@
+div {
+    &.test {
+      color:red;
+    }
+}

--- a/test/files/task/original_2.cssex
+++ b/test/files/task/original_2.cssex
@@ -1,0 +1,7 @@
+@!color blue;
+
+div {
+    &.test {
+      color:<$color$>;
+    }
+}

--- a/test/task_test.exs
+++ b/test/task_test.exs
@@ -15,13 +15,13 @@ defmodule CSSEx.Task.Test do
     {:ok, cwd} = File.cwd()
 
     root = Path.join([cwd, @root])
-    
+
     base_path = Path.join([root, @base])
     assert File.exists?(base_path)
 
     base_path_2 = Path.join([root, @base_2])
     assert File.exists?(base_path_2)
-    
+
     dest_path = Path.join([root, @dest_path])
     dest_path_2 = Path.join([root, @dest_path_2])
     dest_same_path = Path.join([root, @dest_same])
@@ -35,44 +35,54 @@ defmodule CSSEx.Task.Test do
     refute File.exists?(dest_same_path)
 
     base_without_cwd = Path.join(["../../../..", @root, @base])
-    base_2_without_cwd  = Path.join(["../../../..", @root, @base_2])
+    base_2_without_cwd = Path.join(["../../../..", @root, @base_2])
     dest_without_cwd = Path.join(["../../../..", @root, @dest_path])
     dest_2_without_cwd = Path.join(["../../../..", @root, @dest_path_2])
 
     entry_points_1 = [{base_without_cwd, dest_without_cwd}]
     entry_points_2 = [{base_2_without_cwd, dest_2_without_cwd} | entry_points_1]
-    
-    {:ok, %{
-	base_path: base_path,
-	base_path_2: base_path_2,
-	dest_path: dest_path,
-	dest_path_2: dest_path_2,
-	dest_same_dest: dest_same_path,
-	base_without: base_without_cwd,
-	dest_without: dest_without_cwd,
-	entry_points_1: entry_points_1,
-	entry_points_2: entry_points_2
+
+    {:ok,
+     %{
+       base_path: base_path,
+       base_path_2: base_path_2,
+       dest_path: dest_path,
+       dest_path_2: dest_path_2,
+       dest_same_dest: dest_same_path,
+       base_without: base_without_cwd,
+       dest_without: dest_without_cwd,
+       entry_points_1: entry_points_1,
+       entry_points_2: entry_points_2
      }}
   end
-  
-  test "processing with flag --c works", %{entry_points_1: eps, base_path: base_path, dest_path: dest_path} do
-    Application.put_env(:cssex, CSSEx, [entry_points: eps])
+
+  test "processing with flag --c works", %{
+    entry_points_1: eps,
+    base_path: base_path,
+    dest_path: dest_path
+  } do
+    Application.put_env(:cssex, CSSEx, entry_points: eps)
 
     assert capture_log(fn ->
-      Mix.Tasks.Cssex.Parser.run(["--c", "cssex"]) end
-    ) =~ "PROCESSED :: #{base_path} into \"#{dest_path}"
+             Mix.Tasks.Cssex.Parser.run(["--c", "cssex"])
+           end) =~ "PROCESSED :: #{base_path} into \"#{dest_path}"
 
     assert {:ok, "div.test{color:red;}\n"} = File.read(dest_path)
   end
 
-  
+  test "processing with flag --c and multiple entry points works", %{
+    entry_points_2: eps,
+    base_path: base_path,
+    dest_path: dest_path,
+    base_path_2: base_path_2,
+    dest_path_2: dest_path_2
+  } do
+    Application.put_env(:cssex, CSSEx, entry_points: eps)
 
-  test "processing with flag --c and multiple entry points works", %{entry_points_2: eps, base_path: base_path, dest_path: dest_path, base_path_2: base_path_2, dest_path_2: dest_path_2} do
-    Application.put_env(:cssex, CSSEx, [entry_points: eps])
-
-    assert capture = capture_log(fn ->
-      Mix.Tasks.Cssex.Parser.run(["--c", "cssex"]) end
-    )
+    assert capture =
+             capture_log(fn ->
+               Mix.Tasks.Cssex.Parser.run(["--c", "cssex"])
+             end)
 
     assert capture =~ "PROCESSED :: #{base_path} into \"#{dest_path}"
     assert capture =~ "PROCESSED :: #{base_path_2} into \"#{dest_path_2}"
@@ -81,119 +91,116 @@ defmodule CSSEx.Task.Test do
     assert {:ok, "div.test{color:blue;}\n"} = File.read(dest_path_2)
   end
 
-  
-
-  test "processing with flag --c and multiple entry points, one of which bad, exits with error", %{entry_points_2: eps, base_path: base_path, dest_path: dest_path, base_path_2: base_path_2, dest_path_2: dest_path_2} do
-
+  test "processing with flag --c and multiple entry points, one of which bad, exits with error",
+       %{
+         entry_points_2: eps,
+         base_path: base_path,
+         dest_path: dest_path,
+         base_path_2: base_path_2,
+         dest_path_2: dest_path_2
+       } do
     new_eps = [{@no_bueno_path, String.replace(@no_bueno_path, ".cssex", ".css")} | eps]
-    Application.put_env(:cssex, CSSEx, [entry_points: new_eps])
+    Application.put_env(:cssex, CSSEx, entry_points: new_eps)
 
-    assert capture = capture_log(fn ->
-      try do
-	Mix.Tasks.Cssex.Parser.run(["--c", "cssex"])
-      catch
-	:exit, {:shutdown, 1} -> :ok
-      end
-    end				 
-    )
+    assert capture =
+             capture_log(fn ->
+               try do
+                 Mix.Tasks.Cssex.Parser.run(["--c", "cssex"])
+               catch
+                 :exit, {:shutdown, 1} -> :ok
+               end
+             end)
 
     assert capture =~ "PROCESSED :: #{base_path} into \"#{dest_path}"
     assert capture =~ "PROCESSED :: #{base_path_2} into \"#{dest_path_2}"
     assert capture =~ "ERROR :: \"\\\"unable to find file"
-    assert capture =~  @no_bueno_path
+    assert capture =~ @no_bueno_path
 
     assert {:ok, "div.test{color:red;}\n"} = File.read(dest_path)
     assert {:ok, "div.test{color:blue;}\n"} = File.read(dest_path_2)
   end
 
-  
-
   test "processing with flag --e works", %{base_path: base_path, dest_path: dest_path} do
-
     assert capture_log(fn ->
-      Mix.Tasks.Cssex.Parser.run(["--e", "#{base_path}=#{dest_path}"]) end
-    ) =~ "PROCESSED :: #{base_path} into \"#{dest_path}"
-
-    assert {:ok, "div.test{color:red;}\n"} = File.read(dest_path)
-    
-  end
-
-
-
-  test "processing with flag --e and --a works", %{base_path: base_path, base_without: base_without, dest_without: dest_without, dest_path: dest_path} do
-
-    assert capture_log(fn ->
-      Mix.Tasks.Cssex.Parser.run(["--e", "#{base_without}=#{dest_without}", "--a", "cssex"]) end
-    ) =~ "PROCESSED :: #{base_path} into \"#{dest_path}"
+             Mix.Tasks.Cssex.Parser.run(["--e", "#{base_path}=#{dest_path}"])
+           end) =~ "PROCESSED :: #{base_path} into \"#{dest_path}"
 
     assert {:ok, "div.test{color:red;}\n"} = File.read(dest_path)
   end
 
-  
-
-  test "processing with flag --e and only origin path works", %{base_path: base_path, dest_same_dest: dest_path} do
-
+  test "processing with flag --e and --a works", %{
+    base_path: base_path,
+    base_without: base_without,
+    dest_without: dest_without,
+    dest_path: dest_path
+  } do
     assert capture_log(fn ->
-      Mix.Tasks.Cssex.Parser.run(["--e", "#{base_path}"]) end
-    ) =~ "PROCESSED :: #{base_path} into \"#{dest_path}"
+             Mix.Tasks.Cssex.Parser.run(["--e", "#{base_without}=#{dest_without}", "--a", "cssex"])
+           end) =~ "PROCESSED :: #{base_path} into \"#{dest_path}"
 
     assert {:ok, "div.test{color:red;}\n"} = File.read(dest_path)
   end
 
-  
-
-  test "processing with flag --e and --a and only origin path works", %{base_path: base_path, base_without: base_without, dest_same_dest: dest_path} do
-
+  test "processing with flag --e and only origin path works", %{
+    base_path: base_path,
+    dest_same_dest: dest_path
+  } do
     assert capture_log(fn ->
-      Mix.Tasks.Cssex.Parser.run(["--e", "#{base_without}", "--a", "cssex"]) end
-    ) =~ "PROCESSED :: #{base_path} into \"#{dest_path}"
+             Mix.Tasks.Cssex.Parser.run(["--e", "#{base_path}"])
+           end) =~ "PROCESSED :: #{base_path} into \"#{dest_path}"
 
     assert {:ok, "div.test{color:red;}\n"} = File.read(dest_path)
   end
 
+  test "processing with flag --e and --a and only origin path works", %{
+    base_path: base_path,
+    base_without: base_without,
+    dest_same_dest: dest_path
+  } do
+    assert capture_log(fn ->
+             Mix.Tasks.Cssex.Parser.run(["--e", "#{base_without}", "--a", "cssex"])
+           end) =~ "PROCESSED :: #{base_path} into \"#{dest_path}"
 
-  
+    assert {:ok, "div.test{color:red;}\n"} = File.read(dest_path)
+  end
+
   test "errors out with invalid paths" do
-    assert capture = capture_log(fn ->
-      try do
-	Mix.Tasks.Cssex.Parser.run(["--e", @no_bueno_path, "--a", "cssex"])
-      catch
-	:exit, {:shutdown, 1} -> :ok
-      end
-    end
-    )
+    assert capture =
+             capture_log(fn ->
+               try do
+                 Mix.Tasks.Cssex.Parser.run(["--e", @no_bueno_path, "--a", "cssex"])
+               catch
+                 :exit, {:shutdown, 1} -> :ok
+               end
+             end)
 
     assert capture =~ "ERROR :: \"\\\"unable to find file"
     assert capture =~ @no_bueno_path
   end
 
-  
-
   test "errors out without options" do
-    assert captured = capture_log(fn ->
-      try do
-	Mix.Tasks.Cssex.Parser.run([])
-      catch
-	:exit, {:shutdown, 64} -> :ok
-      end
-    end
-    )
+    assert captured =
+             capture_log(fn ->
+               try do
+                 Mix.Tasks.Cssex.Parser.run([])
+               catch
+                 :exit, {:shutdown, 64} -> :ok
+               end
+             end)
 
     assert captured =~ "ERROR ::"
     assert captured =~ "specify the file paths"
   end
 
-  
-
   test "errors with invalid options" do
-    assert captured = capture_log(fn ->
-      try do
-	Mix.Tasks.Cssex.Parser.run(["--d"])
-      catch
-	:exit, {:shutdown, 64} -> :ok
-      end
-    end
-    )
+    assert captured =
+             capture_log(fn ->
+               try do
+                 Mix.Tasks.Cssex.Parser.run(["--d"])
+               catch
+                 :exit, {:shutdown, 64} -> :ok
+               end
+             end)
 
     assert captured =~ "ERROR ::"
     assert captured =~ "no paths given"

--- a/test/task_test.exs
+++ b/test/task_test.exs
@@ -1,0 +1,201 @@
+defmodule CSSEx.Task.Test do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  @root "test/files/task"
+  @base "original.cssex"
+  @base_2 "original_2.cssex"
+  @dest_path "finished/base.css"
+  @dest_path_2 "finished/base_2.css"
+  @dest_same String.replace(@base, ".cssex", ".css")
+  @no_bueno_path "/no/bueno/path.cssex"
+
+  setup do
+    {:ok, cwd} = File.cwd()
+
+    root = Path.join([cwd, @root])
+    
+    base_path = Path.join([root, @base])
+    assert File.exists?(base_path)
+
+    base_path_2 = Path.join([root, @base_2])
+    assert File.exists?(base_path_2)
+    
+    dest_path = Path.join([root, @dest_path])
+    dest_path_2 = Path.join([root, @dest_path_2])
+    dest_same_path = Path.join([root, @dest_same])
+
+    assert {:ok, _} = File.rm_rf(dest_path)
+    assert {:ok, _} = File.rm_rf(dest_path_2)
+    assert {:ok, _} = File.rm_rf(dest_same_path)
+
+    refute File.exists?(dest_path)
+    refute File.exists?(dest_path_2)
+    refute File.exists?(dest_same_path)
+
+    base_without_cwd = Path.join(["../../../..", @root, @base])
+    base_2_without_cwd  = Path.join(["../../../..", @root, @base_2])
+    dest_without_cwd = Path.join(["../../../..", @root, @dest_path])
+    dest_2_without_cwd = Path.join(["../../../..", @root, @dest_path_2])
+
+    entry_points_1 = [{base_without_cwd, dest_without_cwd}]
+    entry_points_2 = [{base_2_without_cwd, dest_2_without_cwd} | entry_points_1]
+    
+    {:ok, %{
+	base_path: base_path,
+	base_path_2: base_path_2,
+	dest_path: dest_path,
+	dest_path_2: dest_path_2,
+	dest_same_dest: dest_same_path,
+	base_without: base_without_cwd,
+	dest_without: dest_without_cwd,
+	entry_points_1: entry_points_1,
+	entry_points_2: entry_points_2
+     }}
+  end
+  
+  test "processing with flag --c works", %{entry_points_1: eps, base_path: base_path, dest_path: dest_path} do
+    Application.put_env(:cssex, CSSEx, [entry_points: eps])
+
+    assert capture_log(fn ->
+      Mix.Tasks.Cssex.Parser.run(["--c", "cssex"]) end
+    ) =~ "PROCESSED :: #{base_path} into \"#{dest_path}"
+
+    assert {:ok, "div.test{color:red;}\n"} = File.read(dest_path)
+  end
+
+  
+
+  test "processing with flag --c and multiple entry points works", %{entry_points_2: eps, base_path: base_path, dest_path: dest_path, base_path_2: base_path_2, dest_path_2: dest_path_2} do
+    Application.put_env(:cssex, CSSEx, [entry_points: eps])
+
+    assert capture = capture_log(fn ->
+      Mix.Tasks.Cssex.Parser.run(["--c", "cssex"]) end
+    )
+
+    assert capture =~ "PROCESSED :: #{base_path} into \"#{dest_path}"
+    assert capture =~ "PROCESSED :: #{base_path_2} into \"#{dest_path_2}"
+
+    assert {:ok, "div.test{color:red;}\n"} = File.read(dest_path)
+    assert {:ok, "div.test{color:blue;}\n"} = File.read(dest_path_2)
+  end
+
+  
+
+  test "processing with flag --c and multiple entry points, one of which bad, exits with error", %{entry_points_2: eps, base_path: base_path, dest_path: dest_path, base_path_2: base_path_2, dest_path_2: dest_path_2} do
+
+    new_eps = [{@no_bueno_path, String.replace(@no_bueno_path, ".cssex", ".css")} | eps]
+    Application.put_env(:cssex, CSSEx, [entry_points: new_eps])
+
+    assert capture = capture_log(fn ->
+      try do
+	Mix.Tasks.Cssex.Parser.run(["--c", "cssex"])
+      catch
+	:exit, {:shutdown, 1} -> :ok
+      end
+    end				 
+    )
+
+    assert capture =~ "PROCESSED :: #{base_path} into \"#{dest_path}"
+    assert capture =~ "PROCESSED :: #{base_path_2} into \"#{dest_path_2}"
+    assert capture =~ "ERROR :: \"\\\"unable to find file"
+    assert capture =~  @no_bueno_path
+
+    assert {:ok, "div.test{color:red;}\n"} = File.read(dest_path)
+    assert {:ok, "div.test{color:blue;}\n"} = File.read(dest_path_2)
+  end
+
+  
+
+  test "processing with flag --e works", %{base_path: base_path, dest_path: dest_path} do
+
+    assert capture_log(fn ->
+      Mix.Tasks.Cssex.Parser.run(["--e", "#{base_path}=#{dest_path}"]) end
+    ) =~ "PROCESSED :: #{base_path} into \"#{dest_path}"
+
+    assert {:ok, "div.test{color:red;}\n"} = File.read(dest_path)
+    
+  end
+
+
+
+  test "processing with flag --e and --a works", %{base_path: base_path, base_without: base_without, dest_without: dest_without, dest_path: dest_path} do
+
+    assert capture_log(fn ->
+      Mix.Tasks.Cssex.Parser.run(["--e", "#{base_without}=#{dest_without}", "--a", "cssex"]) end
+    ) =~ "PROCESSED :: #{base_path} into \"#{dest_path}"
+
+    assert {:ok, "div.test{color:red;}\n"} = File.read(dest_path)
+  end
+
+  
+
+  test "processing with flag --e and only origin path works", %{base_path: base_path, dest_same_dest: dest_path} do
+
+    assert capture_log(fn ->
+      Mix.Tasks.Cssex.Parser.run(["--e", "#{base_path}"]) end
+    ) =~ "PROCESSED :: #{base_path} into \"#{dest_path}"
+
+    assert {:ok, "div.test{color:red;}\n"} = File.read(dest_path)
+  end
+
+  
+
+  test "processing with flag --e and --a and only origin path works", %{base_path: base_path, base_without: base_without, dest_same_dest: dest_path} do
+
+    assert capture_log(fn ->
+      Mix.Tasks.Cssex.Parser.run(["--e", "#{base_without}", "--a", "cssex"]) end
+    ) =~ "PROCESSED :: #{base_path} into \"#{dest_path}"
+
+    assert {:ok, "div.test{color:red;}\n"} = File.read(dest_path)
+  end
+
+
+  
+  test "errors out with invalid paths" do
+    assert capture = capture_log(fn ->
+      try do
+	Mix.Tasks.Cssex.Parser.run(["--e", @no_bueno_path, "--a", "cssex"])
+      catch
+	:exit, {:shutdown, 1} -> :ok
+      end
+    end
+    )
+
+    assert capture =~ "ERROR :: \"\\\"unable to find file"
+    assert capture =~ @no_bueno_path
+  end
+
+  
+
+  test "errors out without options" do
+    assert captured = capture_log(fn ->
+      try do
+	Mix.Tasks.Cssex.Parser.run([])
+      catch
+	:exit, {:shutdown, 64} -> :ok
+      end
+    end
+    )
+
+    assert captured =~ "ERROR ::"
+    assert captured =~ "specify the file paths"
+  end
+
+  
+
+  test "errors with invalid options" do
+    assert captured = capture_log(fn ->
+      try do
+	Mix.Tasks.Cssex.Parser.run(["--d"])
+      catch
+	:exit, {:shutdown, 64} -> :ok
+      end
+    end
+    )
+
+    assert captured =~ "ERROR ::"
+    assert captured =~ "no paths given"
+  end
+end


### PR DESCRIPTION
Support for parsing files with a mix task.

```
# as it says on the tin
mix cssex.parser --e /original/file/path.cssex=/destination/file/path.css

# output in the same folder dir, with same name, but .css extension
mix cssex.parser --e /original/file/path.cssex

# relative to an application path
mix cssex.parser --e priv/static/path.cssex=priv/static/path.css --a myweb_app

# same but outputs in same dir
mix cssex.parser --e priv/static/path.cssex --a myweb_app

# using the config values for a given app, set under the CSSEx keys (as the file watcher)
mix cssex.parser --c myweb_app
```
