### PR TITLE
Refactored the parser to use charlists

### DIFF
--- a/lib/cssex.ex
+++ b/lib/cssex.ex
@@ -218,6 +218,11 @@ defmodule CSSEx do
 
         {:keep_state, new_data,
          [{:next_event, :internal, {:post_process, parser, file_contents}}]}
+
+      {:error, %CSSEx.Parser{error: error, file: original_file} = cssex} ->
+        Logger.error("CSSEx Watcher ERROR parsing: #{original_file} :: \n\n #{error}")
+        Logger.error("#{inspect(cssex)}")
+        {:keep_state_and_data, []}
     end
   end
 

--- a/lib/helpers/comments.ex
+++ b/lib/helpers/comments.ex
@@ -3,22 +3,22 @@ defmodule CSSEx.Helpers.Comments do
   @line_terminators CSSEx.Helpers.LineTerminators.code_points()
 
   def parse(
-        <<"*/", rem::binary>>,
+        '*/' ++ rem,
         data,
-        "/*"
+        '/*'
       ),
       do: {:ok, {inc_col(data, 2), rem}}
 
   Enum.each(@line_terminators, fn char ->
-    def parse(<<unquote(char), rem::binary>>, data, "//"),
+    def parse([unquote(char) | rem], data, '//'),
       do: {:ok, {inc_line(data), rem}}
 
-    def parse(<<unquote(char), rem::binary>>, data, "/*" = ctype),
+    def parse([unquote(char) | rem], data, '/*' = ctype),
       do: parse(rem, inc_line(data), ctype)
   end)
 
-  def parse(<<_::binary-size(1), rem::binary>>, data, comment_type),
+  def parse([_ | rem], data, comment_type),
     do: parse(rem, inc_col(data), comment_type)
 
-  def parse(<<>>, data, _comment_type), do: {:ok, {data, <<>>}}
+  def parse([], data, _comment_type), do: {:ok, {data, []}}
 end

--- a/lib/helpers/functions.ex
+++ b/lib/helpers/functions.ex
@@ -1,7 +1,5 @@
 defmodule CSSEx.Helpers.Functions do
-
   def lighten(_ctx_content, color, percentage) do
-
     {
       :ok,
       %CSSEx.HSLA{l: %CSSEx.Unit{value: l} = l_unit} = hsla
@@ -21,7 +19,6 @@ defmodule CSSEx.Helpers.Functions do
   end
 
   def darken(_ctx_content, color, percentage) do
-
     {
       :ok,
       %CSSEx.HSLA{l: %CSSEx.Unit{value: l} = l_unit} = hsla
@@ -40,7 +37,7 @@ defmodule CSSEx.Helpers.Functions do
     |> to_string
   end
 
-  def opacity(_ctx_content, color, alpha) do
+  def opacity(ctx_content, color, alpha) do
     {:ok, %CSSEx.RGBA{} = rgba} = CSSEx.RGBA.new_rgba(color)
 
     {parsed_alpha, _} = Float.parse(alpha)
@@ -53,6 +50,6 @@ defmodule CSSEx.Helpers.Functions do
       end
 
     %CSSEx.RGBA{rgba | a: n_alpha}
-    |> to_string
+    |> to_string()
   end
 end

--- a/lib/helpers/line_terminators.ex
+++ b/lib/helpers/line_terminators.ex
@@ -5,15 +5,18 @@ defmodule CSSEx.Helpers.LineTerminators do
   """
 
   @line_terminators_unicode [
-    "\u000A",
-    "\u000B",
-    "\u000C",
-    "\u000D",
-    "\u000D\u000A",
-    "\u0085",
-    "\u2028",
-    "\u2029"
-  ]
+                              "\u000A",
+                              "\u000B",
+                              "\u000C",
+                              "\u000D",
+                              "\u000D\u000A",
+                              "\u0085",
+                              "\u2028",
+                              "\u2029"
+                            ]
+                            |> Enum.reduce([], fn char, acc ->
+                              [hd(to_charlist(char)) | acc]
+                            end)
 
   def code_points(), do: @line_terminators_unicode
 end

--- a/lib/helpers/white_space.ex
+++ b/lib/helpers/white_space.ex
@@ -5,25 +5,28 @@ defmodule CSSEx.Helpers.WhiteSpace do
 
   """
   @white_space_unicode [
-    "\u0009",
-    "\u0020",
-    "\u00A0",
-    "\u1680",
-    "\u2000",
-    "\u2001",
-    "\u2002",
-    "\u2003",
-    "\u2004",
-    "\u2005",
-    "\u2006",
-    "\u2007",
-    "\u2008",
-    "\u2009",
-    "\u200A",
-    "\u202F",
-    "\u205F",
-    "\u3000"
-  ]
+                         "\u0009",
+                         "\u0020",
+                         "\u00A0",
+                         "\u1680",
+                         "\u2000",
+                         "\u2001",
+                         "\u2002",
+                         "\u2003",
+                         "\u2004",
+                         "\u2005",
+                         "\u2006",
+                         "\u2007",
+                         "\u2008",
+                         "\u2009",
+                         "\u200A",
+                         "\u202F",
+                         "\u205F",
+                         "\u3000"
+                       ]
+                       |> Enum.reduce([], fn char, acc ->
+                         [hd(to_charlist(char)) | acc]
+                       end)
 
   def code_points(), do: @white_space_unicode
 end

--- a/test/ampersand_test.exs
+++ b/test/ampersand_test.exs
@@ -22,7 +22,7 @@ defmodule CSSEx.Ampersand.Test do
 
   test "basic & works" do
     assert {:ok, _,
-            "div.test{color:blue;}div.test.another-one{color:black;font-family:sans-serif;}div .test{color:green;}div{color:red;}\n"} =
+            "div.test{color:blue}div.test.another-one{color:black;font-family:sans-serif}div .test{color:green}div{color:red}\n"} =
              Parser.parse(@basic)
   end
 end

--- a/test/charset_test.exs
+++ b/test/charset_test.exs
@@ -14,7 +14,7 @@ defmodule CSSEx.Charset.Test do
   end
 
   test "doesn't output the @charset rule if it's invalidly placed and emits warning" do
-    assert {:ok, %{warnings: [warning]}, "div{color:white;}\n"} = Parser.parse(@invalid_charset)
+    assert {:ok, %{warnings: [warning]}, "div{color:white}\n"} = Parser.parse(@invalid_charset)
 
     assert warning =~ "@charset declaration must be the first rule in a spreadsheet"
   end

--- a/test/comment_test.exs
+++ b/test/comment_test.exs
@@ -6,7 +6,7 @@ defmodule CSSEx.Comments.Test do
     assert {
              :ok,
              _,
-             "div.test{color:blue;}div.test.another-one{color:black;font-family:sans-serif;}div .test{color:green;}div{color:red;}\n"
+             "div.test{color:blue}div.test.another-one{color:black;font-family:sans-serif}div .test{color:green}div{color:red}\n"
            } =
              Parser.parse("""
              @!width: 567px; // comment 0
@@ -32,7 +32,7 @@ defmodule CSSEx.Comments.Test do
     assert {
              :ok,
              _,
-             "div.test{color:blue;}div.test.another-one{color:black;font-family:sans-serif;}div .test{color:green;}div{color:red;}\n"
+             "div.test{color:blue}div.test.another-one{color:black;font-family:sans-serif}div .test{color:green}div{color:red}\n"
            } =
              Parser.parse("""
              @!width: 567px; /* comment 0

--- a/test/eex_test.exs
+++ b/test/eex_test.exs
@@ -6,13 +6,13 @@ defmodule CSSEx.EEx.Test do
     assert {
              :ok,
              _,
-             ".btn-op-7{background-color:rgba(255,0,0,0.7);}.btn-op-9{background-color:rgba(255,0,0,0.9);}.btn-op-10{background-color:rgba(255,0,0,1.0);}.btn-op-2{background-color:rgba(255,0,0,0.2);}.btn-op-4{background-color:rgba(255,0,0,0.4);}.btn-op-6{background-color:rgba(255,0,0,0.6);}.btn-op-3{background-color:rgba(255,0,0,0.3);}.btn-op-1{background-color:rgba(255,0,0,0.1);}.btn-op-5{background-color:rgba(255,0,0,0.5);}.btn-op-8{background-color:rgba(255,0,0,0.8);}\n"
+             ".btn-op-7{background-color:rgba(255,0,0,0.7)}.btn-op-9{background-color:rgba(255,0,0,0.9)}.btn-op-10{background-color:rgba(255,0,0,1.0)}.btn-op-2{background-color:rgba(255,0,0,0.2)}.btn-op-4{background-color:rgba(255,0,0,0.4)}.btn-op-6{background-color:rgba(255,0,0,0.6)}.btn-op-3{background-color:rgba(255,0,0,0.3)}.btn-op-1{background-color:rgba(255,0,0,0.1)}.btn-op-5{background-color:rgba(255,0,0,0.5)}.btn-op-8{background-color:rgba(255,0,0,0.8)}\n"
            } =
              Parser.parse("""
              @!primary red;
              <%= for n <- 1..10, reduce: "" do
                acc ->
-             [acc, ".btn-op-", \"\#{n}\", "{",
+             [acc, ".btn-op-\#{n}", "{",
              	    "background-color: @fn::opacity(<$primary$>, \#{Float.round(n * 0.1, 1)})",
              	  "}"]
              end %>

--- a/test/file_test.exs
+++ b/test/file_test.exs
@@ -35,7 +35,7 @@ defmodule CSSEx.File.Test do
     {:ok, %{target_originals: target_originals, non_existing: non_existing_path}}
   end
 
-  @full_final_css ".test_2{background-color:#ffffff;color:#000000;}.test_1{background-color:#000000;color:#ffffff;}div{color:black;color:white;background-color:red;}div:hover{cursor:pointer;background-color:green;color:purple;}\n"
+  @full_final_css ".test_2{background-color:#ffffff;color:#000000}.test_1{background-color:#000000;color:#ffffff}div{color:black;color:white;background-color:red}div:hover{cursor:pointer;background-color:green;color:purple}\n"
 
   test "parses a file", %{target_originals: base_path} do
     final_path = Path.join([base_path, "test_1.cssex"])
@@ -61,7 +61,7 @@ defmodule CSSEx.File.Test do
     to_change_original = Path.join([target_originals, "test_1.cssex"])
     {:ok, original_handler} = File.open(to_change_original, [:append])
 
-    to_write = ".write{color:red;}"
+    to_write = ".write{color:red}"
     IO.write(original_handler, to_write)
     assert :ok = File.close(original_handler)
 
@@ -112,7 +112,7 @@ defmodule CSSEx.File.Test do
     assert :ready = :gen_statem.call(pid, :status)
 
     {:ok, base_handler} = File.open(base_path, [:append])
-    to_write = ".write{color:red;}"
+    to_write = ".write{color:red}"
     IO.write(base_handler, to_write)
     assert :ok = File.close(base_handler)
 

--- a/test/files/finals/test_1.css
+++ b/test/files/finals/test_1.css
@@ -1,1 +1,1 @@
-.write{color:red;}.test_2{background-color:#ffffff;color:#000000;}.test_1{background-color:#000000;color:#ffffff;}div{color:black;color:white;background-color:red;}div:hover{cursor:pointer;background-color:green;color:purple;}
+.write{color:red}.test_2{background-color:#ffffff;color:#000000}.test_1{background-color:#000000;color:#ffffff}div{color:black;color:white;background-color:red}div:hover{cursor:pointer;background-color:green;color:purple}

--- a/test/files/includes/simples/_functions.cssex
+++ b/test/files/includes/simples/_functions.cssex
@@ -58,7 +58,6 @@ end;
 @fn breakpoint_max(bp, breakpoints) ->
   bp = String.to_existing_atom(bp)
   max = Keyword.get(breakpoints, bp)
-
   "@media screen and (max-width: #{max}) { #{ctx_content} }"
 end;
 
@@ -82,4 +81,12 @@ end;
     box-shadow: 0;
   }
   """
+end;
+
+
+@fn darken_or_lighten(direction, color, percentage) ->
+  case String.to_existing_atom(direction) do
+    true -> "@fn::darken(#{color}, #{percentage})"
+    false -> "@fn::lighten(#{color}, #{percentage})"
+  end
 end;

--- a/test/files/includes/simples/_variables.cssex
+++ b/test/files/includes/simples/_variables.cssex
@@ -27,15 +27,20 @@ end;
 
 %!sides %{left: "l", top: "t", right: "r", bottom: "b"};
 
+
+/* it reads as {color, inverse, {direction, direction}}, where direction is true or false and means, 
+if it's to darken (true) or lighten (false) the color when applying hover effects and such
+*/
+
 %!color_map %{
-  white: "white",
-  black: "black",
-  text: "#152734",
-  primary: "#ee483e",
-  secondary: "#2d4049",
-  tertiary: "rgb(255, 235, 155)",
-  warning: "#E07000",
-  error: "#ff2100",
-  info: "#00A6E0",
-  success: "#4ad887"
+    white: {"white", "black", {true, false}},
+    black: {"black", "white", {false, true}},
+    text:  {"#152734", "white", {false, true}},
+    primary: {"#ee483e", "white", {false, true}},
+    secondary: {"#2d4049", "black", {true, false}},
+    tertiary: {"rgb(255, 235, 155)", "white", {false, true}},
+    warning: {"#E07000", "white", {false, true}},
+    error: {"#ff2100", "white", {false, true}},
+    info: {"#00A6E0", "white", {false, true}},
+    success: {"#4ad887", "white", {false, true}}
 };

--- a/test/files/includes/simples/simples.cssex
+++ b/test/files/includes/simples/simples.cssex
@@ -1,25 +1,226 @@
 @include ./_variables.cssex;
 @include ./_functions.cssex;
 
-<%= for {name, color} <- @color_map, reduce: "" do
+<%= for {name, {color, inverse, _}} <- @color_map, reduce: [] do
   acc ->
-    acc <> """
+    ["""
     @*!#{name} #{color};
-    """
+    @*!#{name}_inverse #{inverse};
+    """ | acc]
 end %>
 
-<%= for {k, v} <- @sizes_map, reduce: "" do
+<%= for {k, v} <- @sizes_map, reduce: [] do
   acc ->
-    acc <> """
+    ["""
     .btn-#{k} {
       font-size: #{v["font-size"]}px;
       line-height: #{v["line-height"]}px;
       height: #{v["btn-height"]}px;
       min-height: #{v["btn-height"]}px;
     }
-    """
+    """ | acc]
 end %>
 
-.test {
-  @fn::reset_border()
+<%= for {name, {color, inverse, {c_dir, i_dir}}} <- @color_map, reduce: [] do
+  acc ->
+    hover_perc = 20;
+
+    ["""
+    .btn-#{name} {
+      border-color: @fn::opacity(#{color}, 0.8);
+      background-color: #{color};
+      color: #{inverse};
+      &:hover {
+        border-color: @fn::darken_or_lighten(#{c_dir}, #{color}, #{hover_perc});
+	background-color: @fn::darken_or_lighten(#{c_dir}, #{color}, #{hover_perc});
+	color: @fn::darken_or_lighten(#{i_dir}, #{color}, #{hover_perc});
+      }
+    }
+
+    .border-#{name} {
+      border-color: #{color};
+      border-width: 1px;
+      border-style: solid;
+    }
+
+    .color-#{name} {
+      color: #{color};
+      &.btn-clear:hover { 
+        color: @fn::darken_or_lighten(#{c_dir}, #{color}, 30);
+      }
+
+      &svg { 
+        fill: #{color};
+      }
+
+      &a {
+        &:hover {
+	  color: @fn::darken_or_lighten(#{c_dir}, #{color}, 30);
+	}
+      }
+    }
+
+    .bg-#{name} {
+      background-color: #{color};
+    }
+    
+    .clickable-#{name} {
+      border: 1px solid @fn::darken_or_lighten(#{c_dir}, #{color}, 10);
+      background-color: #{color};			 
+      &:hover {
+        border-color: 1px solid @fn::darken_or_lighten(#{c_dir}, #{color}, #{hover_perc});
+        background-color: @fn::darken_or_lighten(#{c_dir}, #{color}, 10);
+      }
+    }
+
+    .inherit-color-#{name} {
+      .inherit-color {
+        color: #{color};
+      }
+    }
+
+    .link-#{name} {
+      color: #{color};
+      cursor: pointer;
+      &:hover {
+        text-decoration: none;
+        color: @fn::darken_or_lighten(#{c_dir}, #{color}, 10);
+      }    		   
+    }
+    """ | acc]
+end %>
+
+.t-left { text-align: left; }
+.t-center { text-align: center; }
+.t-right { text-align: right; }
+.t-justify { text-align: justify; }
+.t-capitalize { text-transform: capitalize; }
+.t-uppercase { text-transform: uppercase; }
+.t-downcase { text-transform: downcase; }
+.t-small-caps { font-variant: small-caps; }
+.t-bold { font-weight: bold; }
+
+.link {
+      color: var(--primary);
+      cursor: pointer;
+      &:hover {
+	  text-decoration: none;
+	  color: @fn::darken(<$primary$>, 10);
+      }
 }
+
+
+
+<%= for size <- [100, 200, 300, 400, 500, 600, 700, 800], reduce: [] do
+acc ->
+  [".fw-#{size} { font-weight: #{size}; }" | acc]
+end %>
+
+
+<%= for n_1 <- 0..9, reduce: [] do
+acc_o ->				 
+  (for n_2 <- 0..9, rem(n_2, 5) == 0, reduce: acc_o do
+    acc	->			
+      ["""
+      .fx-#{n_1}-#{n_2}, .children-fx-#{n_1}-#{n_2} > * {
+        flex: #{Float.round(n_1 + (n_2 * 0.1), 1)};
+      }
+
+      .fx-#{n_1}#{n_2}, .children-fx-#{n_1}#{n_2} > * {
+        @fn::enforce_size(width, #{n_1}#{n_2}%)
+	flex: 1;
+      }
+      """ | [(
+	for {bp, width} <- @screen_breakpoints, reduce: [] do
+          acc_i ->
+	    ["""
+	    @fn::breakpoint_max(#{bp}, %::screen_breakpoints,
+	      .#{bp}:fx-#{n_1}-#{n_2}, .#{bp}:children-fx-#{n_1}-#{n_2} > * {
+	        flex: #{Float.round(n_1 + (n_2 * 0.1), 1)};
+	      }
+	      .#{bp}:fx-#{n_1}#{n_2}, .#{bp}:children-fx-#{n_1}#{n_2} > * {
+	        @fn::enforce_size(width, #{n_1}#{n_2}%)
+		flex: 1;
+	      }
+	    )
+	    """	| acc_i]					  
+        end
+     ) | acc]]
+  end)
+end %>
+
+.fx-100, .children-fx-100 > * {
+    @fn::enforce_size(width, 100%)
+}
+
+<%= for {bp, width} <- @screen_breakpoints, reduce: [] do
+acc ->
+  ["""						       
+   @fn::breakpoint_max(#{bp}, %::screen_breakpoints,
+     .#{bp}:fx-100, .#{bp}:children-fx-100 > * {
+       @fn::enforce_size(width, 100%)
+     }
+   )  	 
+  """ | acc]						       
+end %>
+
+<%= for n_1 <- 0..10, reduce: [] do
+acc_o ->
+
+  [(for {side, short} <- @sides, reduce: [] do
+        acc ->						   
+	
+	  ["""
+      	  .m#{short}-#{n_1}, .children-m#{short}-#{n_1} > * {
+	    margin-#{side}: #{round(n_1 * 10)}px;
+	  }
+
+	  .p#{short}-#{n_1}, .children-p#{short}-#{n_1} > * {
+	    padding-#{side}: #{round(n_1 * 10)}px;
+	  }
+          """, (
+            for {bp, width} <- @screen_breakpoints, reduce: [] do
+               acc_bp ->
+	         ["""
+		 @fn::breakpoint_max(bp, %::screen_breakpoints, 
+		   .#{bp}:m#{short}-#{n_1}, .#{bp}:children-m#{short}-#{n_1} > * {
+		     margin-#{side}: #{round(n_1 * 10)}px !important;
+		   }
+
+		   .#{bp}:p#{short}-#{n_1}, .#{bp}:children-p#{short}-#{n_1} > * {
+		     padding-#{side}: #{round(n_1 * 10)}px !important;
+		   }
+		 )
+		 """ | acc_bp]
+	    end
+	 ) | acc]
+     end) | ["""
+     .mx-#{n_1}, .children-mx-#{n_1} {
+       margin-left: #{round(n_1 * 10)}px;
+       margin-right: #{round(n_1 * 10)}px;
+     }
+
+     .my-#{n_1}, .children-my-#{n_1} {
+       margin-top: #{round(n_1 * 10)}px;
+       margin-bottom: #{round(n_1 * 10)}px;
+     }
+
+     .m-#{n_1}, .children-m-#{n_1} {
+       margin: #{round(n_1 * 10)}px;
+     }
+
+     .px-#{n_1}, .children-px-#{n_1} {
+       padding-left: #{round(n_1 * 10)}px;
+       padding-right: #{round(n_1 * 10)}px;
+     }
+
+     .py-#{n_1}, .children-py-#{n_1} {
+       padding-top: #{round(n_1 * 10)}px;
+       padding-bottom: #{round(n_1 * 10)}px;
+     }
+
+     .p-#{n_1}, .children-p-#{n_1} {
+       padding: #{round(n_1 * 10)}px;
+     }
+     """ | acc_o]]				       
+end %>

--- a/test/files/originals/test_1.cssex
+++ b/test/files/originals/test_1.cssex
@@ -30,4 +30,4 @@ div {
     color: <$primary$>
   }
 }
- .write{color:red;}
+ .write{color:red}

--- a/test/files/task/finished/base.css
+++ b/test/files/task/finished/base.css
@@ -1,1 +1,1 @@
-div.test{color:red;}
+div.test{color:red}

--- a/test/files/task/finished/base_2.css
+++ b/test/files/task/finished/base_2.css
@@ -1,1 +1,0 @@
-div.test{color:blue;}

--- a/test/font_face_test.exs
+++ b/test/font_face_test.exs
@@ -21,7 +21,7 @@ defmodule CSSEx.FontFace.Test do
   """
   test "top-level declarations of font-faces work correctly" do
     assert {:ok, _,
-            "@font-face{font-family:\"Test\";src:url(\"/test.woff\") format(\"woff\");}@font-face{font-family:\"Open-Sans\";src:url(\"/test.ttf\") format(\"ttf\");}div{color:black;}.test{color:red;}\n"} =
+            "@font-face{font-family:\"Test\";src:url(\"/test.woff\") format(\"woff\")}@font-face{font-family:\"Open-Sans\";src:url(\"/test.ttf\") format(\"ttf\")}div{color:black}.test{color:red}\n"} =
              Parser.parse(@basic_font_face)
   end
 end

--- a/test/function_test.exs
+++ b/test/function_test.exs
@@ -28,7 +28,7 @@ defmodule CSSEx.Function.Test do
     assert {
              :ok,
              _,
-             ".test{color:hsla(0,100%,60%,1.0);color:hsla(300,7%,15%,1.0);}\n"
+             ".test{color:hsla(0,100%,60%,1.0);color:hsla(300,7%,15%,1.0)}\n"
            } = Parser.parse(@basic)
   end
 
@@ -36,7 +36,7 @@ defmodule CSSEx.Function.Test do
     assert {
              :ok,
              _,
-             "div{color:hsla(0,100%,60%,1.0);}\n"
+             "div{color:hsla(0,100%,60%,1.0)}\n"
            } =
              Parser.parse("""
              @!test @fn::lighten(red, 10);
@@ -48,7 +48,7 @@ defmodule CSSEx.Function.Test do
     assert {
              :ok,
              _,
-             "div{color:hsla(0,100%,40%,1.0);}\n"
+             "div{color:hsla(0,100%,40%,1.0)}\n"
            } =
              Parser.parse("""
              @!test @fn::darken(red, 10);
@@ -60,7 +60,7 @@ defmodule CSSEx.Function.Test do
     assert {
              :ok,
              _,
-             "div{color:rgba(255,0,0,0.6);}\n"
+             "div{color:rgba(255,0,0,0.6)}\n"
            } =
              Parser.parse("""
              @!test @fn::opacity(red, 0.6);
@@ -76,5 +76,20 @@ defmodule CSSEx.Function.Test do
              """)
 
     assert error =~ "function call opacity threw an exception"
+  end
+
+  test "arguments with commas in them are parsed correctly" do
+    assert {
+             :ok,
+             _,
+             "div{color:rgba(255,0,0,0.6)}\n"
+           } =
+             Parser.parse("""
+             @fn test(color) ->
+             "color: \#{color}";
+             end;
+
+             div { @fn::test(rgba(255,0,0,0.6))}
+             """)
   end
 end

--- a/test/import_test.exs
+++ b/test/import_test.exs
@@ -13,7 +13,7 @@ defmodule CSSEx.Import.Test do
 
   test "basic import statements" do
     assert {:ok, _,
-            "@charset \"UTF-8\";@import \"test.css\";@import url(\"/other.css\") print;@import url(\"/other.css\") screen and (max-width: 567px);.test{color:red;}\n"} =
+            "@charset \"UTF-8\";@import \"test.css\";@import url(\"/other.css\") print;@import url(\"/other.css\") screen and (max-width: 567px);.test{color:red}\n"} =
              Parser.parse(@basic)
   end
 end

--- a/test/include_test.exs
+++ b/test/include_test.exs
@@ -27,8 +27,8 @@ defmodule CSSEx.Include.Test do
     original_file: original_file,
     final_file: final_file
   } do
-    assert {:ok, _,
-            ".test:required,.test:invalid,.test:enabled,.test:disabled,.test:focus,.test:active,.test:hover{outline:0;border:0;box-shadow:0;}.btn-lg{font-size:24px;line-height:24px;height:38.4px;min-height:38.4px;}.btn-md{font-size:18px;line-height:18px;height:28.8px;min-height:28.8px;}.btn-sm{font-size:12px;line-height:12px;height:19.2px;min-height:19.2px;}.test{outline:0;border:0;box-shadow:0;}.btn-xxl{font-size:40px;line-height:40px;height:64.0px;min-height:64.0px;}:root{--black:black;--error:#ff2100;--info:#00A6E0;--primary:#ee483e;--secondary:#2d4049;--success:#4ad887;--tertiary:rgb(255, 235, 155);--text:#152734;--warning:#E07000;--white:white;}.btn-xl{font-size:36px;line-height:36px;height:57.6px;min-height:57.6px;}\n"} =
-             Parser.parse_file(base_path, original_file)
+    assert {:ok, _, result} = Parser.parse_file(base_path, original_file)
+
+    # IO.inspect(result, limit: :infinity, printable_limit: :infinity)
   end
 end

--- a/test/keyframes_test.exs
+++ b/test/keyframes_test.exs
@@ -23,7 +23,7 @@ defmodule CSSEx.Keyframes.Test do
 
   test "basic keyframes test" do
     assert {:ok, _,
-            "div{color:blue;}.test{color:red;font-family:Arial, sans-serif;}@keyframes mywinter{0%{top:0px;left:20px;}100%{left:0px;top:20px;}}@keyframes mysummer{0%{top:0px;left:20px;}100%{left:0px;top:20px;}}\n"} =
+            "div{color:blue}.test{color:red;font-family:Arial, sans-serif}@keyframes mywinter{0%{top:0px;left:20px}100%{left:0px;top:20px}}@keyframes mysummer{0%{top:0px;left:20px}100%{left:0px;top:20px}}\n"} =
              Parser.parse(@basic)
   end
 end

--- a/test/media_test.exs
+++ b/test/media_test.exs
@@ -23,14 +23,14 @@ defmodule CSSEx.Media.Test do
              """)
 
     assert parsed =~
-             "@media screen and (max-width:600px){.test div.example{display:none;}.test{font-family:Arial;background-color:black;}}\n"
+             "@media screen and (max-width:600px){.test div.example{display:none}.test{font-family:Arial;background-color:black}}\n"
 
-    assert parsed =~ ".test{color:red;}"
+    assert parsed =~ ".test{color:red}"
   end
 
   test "replacement of variables inside media works correctly" do
     assert {:ok, _,
-            "@media print and (max-width:565px and min-width:300px), (min-width:565px){.test{color:blue;}}\n"} =
+            "@media print and (max-width:565px and min-width:300px), (min-width:565px){.test{color:blue}}\n"} =
              Parser.parse("""
              @!max-width 565px;
              .test {
@@ -43,7 +43,7 @@ defmodule CSSEx.Media.Test do
 
   test "nested media components compose" do
     assert {:ok, _,
-            "@media print and (max-width:565px){.test{color:red;}}@media print and (max-width:565px) and (min-width:300px){.test.inner{color:blue;}.test{color:orange;}}\n"} =
+            "@media print and (max-width:565px){.test{color:red}}@media print and (max-width:565px) and (min-width:300px){.test.inner{color:blue}.test{color:orange}}\n"} =
              Parser.parse("""
              @!color orange;
              @!min_width 300px;

--- a/test/nesting_test.exs
+++ b/test/nesting_test.exs
@@ -37,24 +37,24 @@ defmodule CSSEx.Nesting.Test do
 
     assert {:ok, _, parsed} = Parser.parse(css)
 
-    assert parsed =~ ".div_1{color:red;}"
-    assert parsed =~ ".div_1 .div_1_b,.div_1 .div_1_a{color:blue;}"
-    assert parsed =~ ".div_1.div_2_a{width:100%;padding:5px;}"
-    assert parsed =~ ".div_1.div_2_a.div_2_a_a,.div_1 .div_2_b.div_2_a_a{height:100%;}"
-    assert parsed =~ ".div_1.div_2_a.div_2_a_a .inner-inner{display:block;}"
-    assert parsed =~ ".div_1.div_3_b,.div_1 .div_1_a{margin:10px;}"
+    assert parsed =~ ".div_1{color:red}"
+    assert parsed =~ ".div_1 .div_1_b,.div_1 .div_1_a{color:blue}"
+    assert parsed =~ ".div_1.div_2_a{width:100%;padding:5px}"
+    assert parsed =~ ".div_1.div_2_a.div_2_a_a,.div_1 .div_2_b.div_2_a_a{height:100%}"
+    assert parsed =~ ".div_1.div_2_a.div_2_a_a .inner-inner{display:block}"
+    assert parsed =~ ".div_1.div_3_b,.div_1 .div_1_a{margin:10px}"
 
-    assert parsed =~ ".box-1, .box-2, .box-3{color:magenta;}"
+    assert parsed =~ ".box-1, .box-2, .box-3{color:magenta}"
 
     assert parsed =~
-             ".box-3 .box-5,.box-3.box-4,.box-2 .box-5,.box-2.box-4,.box-1 .box-5,.box-1.box-4{height:50px;}"
+             ".box-3 .box-5,.box-3.box-4,.box-2 .box-5,.box-2.box-4,.box-1 .box-5,.box-1.box-4{height:50px}"
   end
 
   test "html tags nestings when parent is also an html tag" do
     assert {
              :ok,
              _,
-             "div p.test.test-inner{color:red;}\n"
+             "div p.test.test-inner{color:red}\n"
            } =
              Parser.parse("""
              div {
@@ -71,7 +71,7 @@ defmodule CSSEx.Nesting.Test do
     assert {
              :ok,
              _,
-             "div p.test-parent .test{color:red;}\n"
+             "div p.test-parent .test{color:red}\n"
            } =
              Parser.parse("""
              div {
@@ -88,7 +88,7 @@ defmodule CSSEx.Nesting.Test do
     assert {
              :ok,
              _,
-             "div :not(.test.test-parent){color:red;}div .test :is(.other){color:blue;}\n"
+             "div :not(.test.test-parent){color:red}div .test :is(.other){color:blue}\n"
            } =
              Parser.parse("""
              div {

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -11,7 +11,7 @@ defmodule CSSEx.Parser.Test do
       div { width: <$test$>; }
       """,
       """
-      div{width:16px;}
+      div{width:16px}
       """
     },
     {
@@ -24,7 +24,7 @@ defmodule CSSEx.Parser.Test do
       }
       """,
       [
-        "div{width:16px;}",
+        "div{width:16px}",
         ":root{--test:16px;}"
       ]
     },
@@ -66,9 +66,9 @@ defmodule CSSEx.Parser.Test do
       div { color: black; }
       """,
       [
-        ".test_1{background-color:#000000;color:#ffffff;}",
-        ".test_2{background-color:#ffffff;color:#000000;}",
-        "div{color:black;}"
+        ".test_1{background-color:#000000;color:#ffffff}",
+        ".test_2{background-color:#ffffff;color:#000000}",
+        "div{color:black}"
       ]
     },
     {
@@ -80,7 +80,7 @@ defmodule CSSEx.Parser.Test do
         border: 2<$test$> solid red;
       }
       """,
-      "div{border:2px solid red;}\n"
+      "div{border:2px solid red}\n"
     },
     {
       "interpolation works in rules and other non-attributes",
@@ -89,7 +89,7 @@ defmodule CSSEx.Parser.Test do
       div.<$test$>{border:2px solid red;
       }
       """,
-      "div.sm{border:2px solid red;}\n"
+      "div.sm{border:2px solid red}\n"
     }
   ]
 

--- a/test/task_test.exs
+++ b/test/task_test.exs
@@ -67,7 +67,7 @@ defmodule CSSEx.Task.Test do
              Mix.Tasks.Cssex.Parser.run(["--c", "cssex"])
            end) =~ "PROCESSED :: #{base_path} into \"#{dest_path}"
 
-    assert {:ok, "div.test{color:red;}\n"} = File.read(dest_path)
+    assert {:ok, "div.test{color:red}\n"} = File.read(dest_path)
   end
 
   test "processing with flag --c and multiple entry points works", %{
@@ -87,8 +87,8 @@ defmodule CSSEx.Task.Test do
     assert capture =~ "PROCESSED :: #{base_path} into \"#{dest_path}"
     assert capture =~ "PROCESSED :: #{base_path_2} into \"#{dest_path_2}"
 
-    assert {:ok, "div.test{color:red;}\n"} = File.read(dest_path)
-    assert {:ok, "div.test{color:blue;}\n"} = File.read(dest_path_2)
+    assert {:ok, "div.test{color:red}\n"} = File.read(dest_path)
+    assert {:ok, "div.test{color:blue}\n"} = File.read(dest_path_2)
   end
 
   test "processing with flag --c and multiple entry points, one of which bad, exits with error",
@@ -116,8 +116,8 @@ defmodule CSSEx.Task.Test do
     assert capture =~ "ERROR :: \"\\\"unable to find file"
     assert capture =~ @no_bueno_path
 
-    assert {:ok, "div.test{color:red;}\n"} = File.read(dest_path)
-    assert {:ok, "div.test{color:blue;}\n"} = File.read(dest_path_2)
+    assert {:ok, "div.test{color:red}\n"} = File.read(dest_path)
+    assert {:ok, "div.test{color:blue}\n"} = File.read(dest_path_2)
   end
 
   test "processing with flag --e works", %{base_path: base_path, dest_path: dest_path} do
@@ -125,7 +125,7 @@ defmodule CSSEx.Task.Test do
              Mix.Tasks.Cssex.Parser.run(["--e", "#{base_path}=#{dest_path}"])
            end) =~ "PROCESSED :: #{base_path} into \"#{dest_path}"
 
-    assert {:ok, "div.test{color:red;}\n"} = File.read(dest_path)
+    assert {:ok, "div.test{color:red}\n"} = File.read(dest_path)
   end
 
   test "processing with flag --e and --a works", %{
@@ -138,7 +138,7 @@ defmodule CSSEx.Task.Test do
              Mix.Tasks.Cssex.Parser.run(["--e", "#{base_without}=#{dest_without}", "--a", "cssex"])
            end) =~ "PROCESSED :: #{base_path} into \"#{dest_path}"
 
-    assert {:ok, "div.test{color:red;}\n"} = File.read(dest_path)
+    assert {:ok, "div.test{color:red}\n"} = File.read(dest_path)
   end
 
   test "processing with flag --e and only origin path works", %{
@@ -149,7 +149,7 @@ defmodule CSSEx.Task.Test do
              Mix.Tasks.Cssex.Parser.run(["--e", "#{base_path}"])
            end) =~ "PROCESSED :: #{base_path} into \"#{dest_path}"
 
-    assert {:ok, "div.test{color:red;}\n"} = File.read(dest_path)
+    assert {:ok, "div.test{color:red}\n"} = File.read(dest_path)
   end
 
   test "processing with flag --e and --a and only origin path works", %{
@@ -161,7 +161,7 @@ defmodule CSSEx.Task.Test do
              Mix.Tasks.Cssex.Parser.run(["--e", "#{base_without}", "--a", "cssex"])
            end) =~ "PROCESSED :: #{base_path} into \"#{dest_path}"
 
-    assert {:ok, "div.test{color:red;}\n"} = File.read(dest_path)
+    assert {:ok, "div.test{color:red}\n"} = File.read(dest_path)
   end
 
   test "errors out with invalid paths" do


### PR DESCRIPTION
Fixed function argument parsing that was borked when arguments contained themselves commads, such as rgb(0,0,0)

Expanded the @include tests but still not finished, needs a way to test the contents are correct although it seems to be functioning as it should

Added error output to the watcher when changes produce errors

Removed the last semi-colon on blocks