### PR TITLE
Implicit ordering of selectors & file events

### DIFF
--- a/lib/cssex.ex
+++ b/lib/cssex.ex
@@ -209,7 +209,7 @@ defmodule CSSEx do
   end
 
   def handle_event(:info, {:file_event, _worker_pid, {file_path, events}}, _, data) do
-    case :modified in events do
+    case :modified in events and :closed in events do
       false ->
         {:keep_state_and_data, []}
 

--- a/lib/helpers/output.ex
+++ b/lib/helpers/output.ex
@@ -1,25 +1,22 @@
 defmodule CSSEx.Helpers.Output do
   @enforce_keys [:data]
-  defstruct [:data, :to_file, valid?: true, acc: []]
+  @temp_ext "-cssex.temp"
+  defstruct [:data, :to_file, :file_path, valid?: true, acc: []]
 
-  def do_finish(%{ets: ets, to_file: nil} = data) do
+  def do_finish(%{to_file: nil} = data) do
     %__MODULE__{data: data}
     |> finish()
   end
 
-  def do_finish(%{ets: ets, to_file: to_file} = data) do
-    base = %__MODULE__{data: data}
+  def do_finish(%{to_file: to_file} = data) do
+    base = %__MODULE__{data: data, file_path: to_file}
 
     case File.mkdir_p(Path.dirname(to_file)) do
       :ok ->
-        case File.open(to_file, [:write, :raw]) do
+        case File.open("#{to_file}#{@temp_ext}", [:write, :raw]) do
           {:ok, io_device} ->
-            try do
-              %__MODULE__{base | to_file: io_device}
-              |> finish()
-            after
-              File.close(to_file)
-            end
+            %__MODULE__{base | to_file: io_device}
+            |> finish()
 
           error ->
             add_error(base, error)
@@ -58,7 +55,6 @@ defmodule CSSEx.Helpers.Output do
   def maybe_add_charset(
         %__MODULE__{
           to_file: to_file,
-          acc: acc,
           data: %CSSEx.Parser{charset: charset},
           valid?: true
         } = ctx
@@ -124,19 +120,19 @@ defmodule CSSEx.Helpers.Output do
         %__MODULE__{
           to_file: nil,
           acc: acc,
-          data: %CSSEx.Parser{ets: ets}
+          data: %CSSEx.Parser{ets: ets, order_map: om}
         } = ctx
       ),
-      do: %__MODULE__{ctx | acc: [acc | fold_attributes_table(ets)]}
+      do: %__MODULE__{ctx | acc: [acc | fold_attributes_table(ets, om)]}
 
   def add_general(
         %__MODULE__{
           to_file: to_file,
-          data: %CSSEx.Parser{ets: ets},
+          data: %CSSEx.Parser{ets: ets, order_map: om},
           valid?: true
         } = ctx
       ) do
-    case fold_attributes_table(ets, to_file) do
+    case fold_attributes_table(ets, om, to_file) do
       :ok -> ctx
       error -> add_error(ctx, error)
     end
@@ -152,8 +148,8 @@ defmodule CSSEx.Helpers.Output do
         } = ctx
       ) do
     new_acc =
-      Enum.reduce(media, acc, fn {media_rule, ets_table}, acc ->
-        [acc, media_rule, "{", fold_attributes_table(ets_table), "}"]
+      Enum.reduce(media, acc, fn {media_rule, {ets_table, om}}, acc ->
+        [acc, media_rule, "{", fold_attributes_table(ets_table, om), "}"]
       end)
 
     %__MODULE__{ctx | acc: new_acc}
@@ -166,10 +162,10 @@ defmodule CSSEx.Helpers.Output do
           valid?: true
         } = ctx
       ) do
-    Enum.reduce_while(media, :ok, fn {media_rule, ets_table}, _acc ->
+    Enum.reduce_while(media, :ok, fn {media_rule, {ets_table, om}}, _acc ->
       case IO.binwrite(to_file, [media_rule, "{"]) do
         :ok ->
-          case fold_attributes_table(ets_table, to_file) do
+          case fold_attributes_table(ets_table, om, to_file) do
             :ok ->
               case IO.binwrite(to_file, "}") do
                 :ok -> {:cont, :ok}
@@ -196,23 +192,25 @@ defmodule CSSEx.Helpers.Output do
         %__MODULE__{
           to_file: nil,
           acc: acc,
-          data: %CSSEx.Parser{ets_keyframes: ets}
+          data: %CSSEx.Parser{ets_keyframes: ets, keyframes_order_map: om}
         } = ctx
       ),
-      do: %__MODULE__{ctx | acc: [acc | fold_attributes_table(ets)]}
+      do: %__MODULE__{ctx | acc: [acc | fold_attributes_table(ets, om)]}
 
   def maybe_add_keyframes(
         %__MODULE__{
           to_file: to_file,
-          data: %CSSEx.Parser{ets_keyframes: ets},
+          data: %CSSEx.Parser{ets_keyframes: ets, keyframes_order_map: om},
           valid?: true
         } = ctx
       ) do
-    case fold_attributes_table(ets, to_file) do
+    case fold_attributes_table(ets, om, to_file) do
       :ok -> ctx
       error -> add_error(ctx, error)
     end
   end
+
+  def maybe_add_keyframes(ctx), do: ctx
 
   def add_final_new_line(
         %__MODULE__{
@@ -225,18 +223,33 @@ defmodule CSSEx.Helpers.Output do
   def add_final_new_line(
         %__MODULE__{
           to_file: to_file,
-          valid?: true
+          valid?: true,
+          file_path: file_path
         } = ctx
       ) do
     case IO.binwrite(to_file, "\n") do
-      :ok -> ctx
-      error -> add_error(ctx, error)
+      :ok ->
+        case File.close(to_file) do
+          :ok ->
+            case File.cp("#{file_path}#{@temp_ext}", file_path) do
+              :ok ->
+                spawn(fn -> File.rm!("#{file_path}#{@temp_ext}") end)
+                ctx
+
+              error ->
+                add_error(ctx, error)
+            end
+
+          error ->
+            add_error(ctx, error)
+        end
+
+      error ->
+        add_error(ctx, error)
     end
   end
 
   def add_final_new_line(ctx), do: ctx
-
-  def maybe_add_keyframes(ctx), do: ctx
 
   def fold_attributes_table(ets) do
     :ets.foldl(
@@ -248,17 +261,42 @@ defmodule CSSEx.Helpers.Output do
     )
   end
 
-  def fold_attributes_table(ets, to_file) do
-    :ets.foldl(
-      fn {selector, attributes}, acc ->
-        case acc == :ok && IO.binwrite(to_file, [selector, "{", attributes, "}"]) do
-          :ok -> :ok
-          error -> error
+  def fold_attributes_table(ets, %{c: c} = om) do
+    Enum.reduce(0..c, [], fn n, acc ->
+      selector = Map.get(om, n)
+
+      case :ets.lookup(ets, selector) do
+        [] ->
+          acc
+
+        [{_, []}] ->
+          acc
+
+        [{_, attrs}] ->
+          [acc, selector, "{", attrs, "}"]
+      end
+    end)
+  end
+
+  def fold_attributes_table(ets, %{c: c} = om, to_file) do
+    Enum.reduce(0..c, :ok, fn
+      n, :ok ->
+        selector = Map.get(om, n)
+
+        case :ets.lookup(ets, selector) do
+          [] ->
+            :ok
+
+          [{_, []}] ->
+            :ok
+
+          [{_, attrs}] ->
+            case IO.binwrite(to_file, [selector, "{", attrs, "}"]) do
+              :ok -> :ok
+              error -> error
+            end
         end
-      end,
-      :ok,
-      ets
-    )
+    end)
   end
 
   def fold_font_faces_table(ets) do
@@ -294,5 +332,73 @@ defmodule CSSEx.Helpers.Output do
             error: "error trying to write output: #{inspect(error)}"
         }
     }
+  end
+
+  def write_element(
+        %CSSEx.Parser{ets: ets, split_chain: chain, order_map: %{c: c} = om} = data,
+        attr_key,
+        attr_val
+      ) do
+    new_om =
+      case :ets.lookup(ets, chain) do
+        [{_, existing}] ->
+          :ets.insert(ets, {chain, [existing, ";", attr_key, ":", attr_val]})
+          om
+
+        [] ->
+          :ets.insert(ets, {chain, [attr_key, ":", attr_val]})
+
+          om
+          |> Map.put(:c, c + 1)
+          |> Map.put(chain, c)
+          |> Map.put(c, chain)
+      end
+
+    %{data | order_map: new_om}
+  end
+
+  def write_media(to_read_from, to_write_to, om) do
+    :ets.foldl(
+      fn {selector, attributes}, %{c: c} = acc ->
+        case :ets.lookup(to_write_to, selector) do
+          [{_, existing}] ->
+            :ets.insert(to_write_to, {selector, [existing, ";" | attributes]})
+            acc
+
+          [] ->
+            :ets.insert(to_write_to, {selector, attributes})
+
+            acc
+            |> Map.put(:c, c + 1)
+            |> Map.put(selector, c)
+            |> Map.put(c, selector)
+        end
+      end,
+      om,
+      to_read_from
+    )
+  end
+
+  def write_keyframe(
+        %CSSEx.Parser{ets_keyframes: ets, keyframes_order_map: %{c: c} = om} = data,
+        selector,
+        content
+      ) do
+    new_om =
+      case :ets.lookup(ets, selector) do
+        [{_, existing}] ->
+          :ets.insert(ets, {selector, [existing, ";", content]})
+          om
+
+        [] ->
+          :ets.insert(ets, {selector, content})
+
+          om
+          |> Map.put(:c, c + 1)
+          |> Map.put(selector, c)
+          |> Map.put(c, selector)
+      end
+
+    %CSSEx.Parser{data | keyframes_order_map: new_om}
   end
 end

--- a/test/ampersand_test.exs
+++ b/test/ampersand_test.exs
@@ -22,7 +22,7 @@ defmodule CSSEx.Ampersand.Test do
 
   test "basic & works" do
     assert {:ok, _,
-            "div.test{color:blue}div.test.another-one{color:black;font-family:sans-serif}div .test{color:green}div{color:red}\n"} =
+            "div{color:red}div.test{color:blue}div.test.another-one{color:black;font-family:sans-serif}div .test{color:green}\n"} =
              Parser.parse(@basic)
   end
 end

--- a/test/comment_test.exs
+++ b/test/comment_test.exs
@@ -6,7 +6,7 @@ defmodule CSSEx.Comments.Test do
     assert {
              :ok,
              _,
-             "div.test{color:blue}div.test.another-one{color:black;font-family:sans-serif}div .test{color:green}div{color:red}\n"
+             "div{color:red}div.test{color:blue}div.test.another-one{color:black;font-family:sans-serif}div .test{color:green}\n"
            } =
              Parser.parse("""
              @!width: 567px; // comment 0
@@ -32,7 +32,7 @@ defmodule CSSEx.Comments.Test do
     assert {
              :ok,
              _,
-             "div.test{color:blue}div.test.another-one{color:black;font-family:sans-serif}div .test{color:green}div{color:red}\n"
+             "div{color:red}div.test{color:blue}div.test.another-one{color:black;font-family:sans-serif}div .test{color:green}\n"
            } =
              Parser.parse("""
              @!width: 567px; /* comment 0

--- a/test/eex_test.exs
+++ b/test/eex_test.exs
@@ -6,7 +6,7 @@ defmodule CSSEx.EEx.Test do
     assert {
              :ok,
              _,
-             ".btn-op-7{background-color:rgba(255,0,0,0.7)}.btn-op-9{background-color:rgba(255,0,0,0.9)}.btn-op-10{background-color:rgba(255,0,0,1.0)}.btn-op-2{background-color:rgba(255,0,0,0.2)}.btn-op-4{background-color:rgba(255,0,0,0.4)}.btn-op-6{background-color:rgba(255,0,0,0.6)}.btn-op-3{background-color:rgba(255,0,0,0.3)}.btn-op-1{background-color:rgba(255,0,0,0.1)}.btn-op-5{background-color:rgba(255,0,0,0.5)}.btn-op-8{background-color:rgba(255,0,0,0.8)}\n"
+             ".btn-op-1{background-color:rgba(255,0,0,0.1)}.btn-op-2{background-color:rgba(255,0,0,0.2)}.btn-op-3{background-color:rgba(255,0,0,0.3)}.btn-op-4{background-color:rgba(255,0,0,0.4)}.btn-op-5{background-color:rgba(255,0,0,0.5)}.btn-op-6{background-color:rgba(255,0,0,0.6)}.btn-op-7{background-color:rgba(255,0,0,0.7)}.btn-op-8{background-color:rgba(255,0,0,0.8)}.btn-op-9{background-color:rgba(255,0,0,0.9)}.btn-op-10{background-color:rgba(255,0,0,1.0)}\n"
            } =
              Parser.parse("""
              @!primary red;

--- a/test/file_test.exs
+++ b/test/file_test.exs
@@ -41,7 +41,7 @@ defmodule CSSEx.File.Test do
     {:ok, %{target_originals: target_originals, non_existing: non_existing_path}}
   end
 
-  @full_final_css ".test_2{background-color:#ffffff;color:#000000}.test_1{background-color:#000000;color:#ffffff}div{color:black;color:white;background-color:red}div:hover{cursor:pointer;background-color:green;color:purple}\n"
+  @full_final_css ".test_1{background-color:#000000;color:#ffffff}.test_2{background-color:#ffffff;color:#000000}div{color:black;color:white;background-color:red}div:hover{cursor:pointer;background-color:green;color:purple}\n"
 
   test "parses a file", %{target_originals: base_path} do
     final_path = Path.join([base_path, "test_1.cssex"])

--- a/test/files/non_existing/test_1.css
+++ b/test/files/non_existing/test_1.css
@@ -1,0 +1,1 @@
+.write{color:red}

--- a/test/files/non_existing/test_1.cssex
+++ b/test/files/non_existing/test_1.cssex
@@ -1,0 +1,1 @@
+.write{color:red}

--- a/test/keyframes_test.exs
+++ b/test/keyframes_test.exs
@@ -23,7 +23,7 @@ defmodule CSSEx.Keyframes.Test do
 
   test "basic keyframes test" do
     assert {:ok, _,
-            "div{color:blue}.test{color:red;font-family:Arial, sans-serif}@keyframes mywinter{0%{top:0px;left:20px}100%{left:0px;top:20px}}@keyframes mysummer{0%{top:0px;left:20px}100%{left:0px;top:20px}}\n"} =
+            ".test{color:red;font-family:Arial, sans-serif}div{color:blue}@keyframes mysummer{0%{top:0px;left:20px}100%{left:0px;top:20px}}@keyframes mywinter{0%{top:0px;left:20px}100%{left:0px;top:20px}}\n"} =
              Parser.parse(@basic)
   end
 end


### PR DESCRIPTION
Restricted the file system events that trigger a recompilation so that only when the file is closed and modified does it trigger, only tested in linux with inotify tools but produces much less triggers. Another option is some delayed buffering to trigger.

Now instead of writing the final file directly when parsing, it outputs to a temp file and once finished just copies it over and deletes the temp. This was also the cause of several events being fired as it was writing things in loops and it would trigger inotify.

Added implicit ordering of the selectors, since CSS defines itself the selector priority by their position on the stylesheet and browsers have to respect that. 