### PR TITLE
Fixed nesting error when using pre concat inside a post concat

### DIFF
--- a/lib/helpers/assigns.ex
+++ b/lib/helpers/assigns.ex
@@ -1,7 +1,5 @@
 defmodule CSSEx.Helpers.Assigns do
-  @moduledoc """
-  Helpers for parsing a CSSEx assign, given it can be any elixir term/expression to be evaluated it has different rules and should keep all characters until the termination mark, afterwards it should be validated and return either an updated {rem, %CSSEx.Parser{valid?: true}} or {rem, %CSSEx.Parser{valid?: false}} with the error field populated.
-  """
+  @moduledoc false
 
   import CSSEx.Parser, only: [close_current: 1, add_error: 1, add_error: 2]
   import CSSEx.Helpers.Shared, only: [inc_col: 1, inc_line: 1]

--- a/lib/helpers/colors.ex
+++ b/lib/helpers/colors.ex
@@ -1,4 +1,6 @@
 defmodule CSSEx.Helpers.Colors do
+  @moduledoc false
+
   @colors [
     ["aqua", "rgb(0, 255, 255)"],
     ["black", "rgb(0, 0, 0)"],

--- a/lib/helpers/comments.ex
+++ b/lib/helpers/comments.ex
@@ -1,4 +1,6 @@
 defmodule CSSEx.Helpers.Comments do
+  @moduledoc false
+
   import CSSEx.Helpers.Shared, only: [inc_col: 1, inc_col: 2, inc_line: 1]
   @line_terminators CSSEx.Helpers.LineTerminators.code_points()
 

--- a/lib/helpers/eex.ex
+++ b/lib/helpers/eex.ex
@@ -1,4 +1,6 @@
 defmodule CSSEx.Helpers.EEX do
+  @moduledoc false
+
   import CSSEx.Parser, only: [open_current: 2, close_current: 1, add_error: 2]
   import CSSEx.Helpers.Shared, only: [inc_col: 1, inc_col: 2, inc_line: 1, inc_line: 2]
   import CSSEx.Helpers.Error, only: [error_msg: 1]
@@ -88,7 +90,7 @@ defmodule CSSEx.Helpers.EEX do
     do: do_parse(rem, data, inc_col(%{state | acc: [acc, char]}))
 
   def replace_and_extract_assigns(acc, matches, %{assigns: assigns, local_assigns: local_assigns}) do
-    Enum.reduce_while(matches, {acc, []}, fn <<"%::", name::binary>> = full,
+    Enum.reduce_while(matches, {acc, []}, fn <<"@::", name::binary>> = full,
                                              {eex_block, bindings} ->
       case Map.get(local_assigns, name) || Map.get(assigns, name) do
         nil ->
@@ -97,7 +99,7 @@ defmodule CSSEx.Helpers.EEX do
         val ->
           {:cont,
            {
-             String.replace(eex_block, full, fn <<"%::", name::binary>> ->
+             String.replace(eex_block, full, fn <<"@::", name::binary>> ->
                <<"@", name::binary>>
              end),
              [{String.to_atom(name), val} | bindings]

--- a/lib/helpers/error.ex
+++ b/lib/helpers/error.ex
@@ -1,4 +1,6 @@
 defmodule CSSEx.Helpers.Error do
+  @moduledoc false
+
   # this means that the error is being bubbled up
   def error_msg(%{valid?: false, error: error}), do: error
 

--- a/lib/helpers/function.ex
+++ b/lib/helpers/function.ex
@@ -1,4 +1,6 @@
 defmodule CSSEx.Helpers.Function do
+  @moduledoc false
+
   import CSSEx.Helpers.Shared, only: [inc_col: 1, inc_col: 2, inc_line: 1]
   import CSSEx.Parser, only: [add_error: 2]
   import CSSEx.Helpers.Error, only: [error_msg: 1]
@@ -20,6 +22,7 @@ defmodule CSSEx.Helpers.Function do
           "fn(",
           Enum.join(["ctx_content" | args], ","),
           ") -> ",
+          "\nif(ctx_content, do: true, else: false)\n",
           fun_string,
           " end"
         ])
@@ -82,7 +85,7 @@ defmodule CSSEx.Helpers.Function do
       [_, name] ->
         case functions do
           nil -> {name, []}
-          funs -> {name, [nil]}
+          _funs -> {name, [nil]}
         end
 
       _ ->

--- a/lib/helpers/functions.ex
+++ b/lib/helpers/functions.ex
@@ -1,4 +1,6 @@
 defmodule CSSEx.Helpers.Functions do
+  @moduledoc false
+
   def lighten(_ctx_content, color, percentage) do
     {
       :ok,
@@ -37,7 +39,7 @@ defmodule CSSEx.Helpers.Functions do
     |> to_string
   end
 
-  def opacity(ctx_content, color, alpha) do
+  def opacity(_ctx_content, color, alpha) do
     {:ok, %CSSEx.RGBA{} = rgba} = CSSEx.RGBA.new_rgba(color)
 
     {parsed_alpha, _} = Float.parse(alpha)

--- a/lib/helpers/line_terminators.ex
+++ b/lib/helpers/line_terminators.ex
@@ -1,8 +1,8 @@
 defmodule CSSEx.Helpers.LineTerminators do
-  @moduledoc """
-  Helpers for matching on line terminator characters (and 1 sequence) according to the Unicode std.
-  https://en.wikipedia.org/wiki/Newline#Unicode
-  """
+  @moduledoc false
+
+  # Helpers for matching on line terminator characters (and 1 sequence) according to the Unicode std.
+  # https://en.wikipedia.org/wiki/Newline#Unicode
 
   @line_terminators_unicode [
                               "\u000A",

--- a/lib/helpers/media.ex
+++ b/lib/helpers/media.ex
@@ -1,6 +1,9 @@
 defmodule CSSEx.Helpers.Media do
+  @moduledoc false
+
   import CSSEx.Helpers.Shared, only: [inc_col: 1]
   @line_terminators CSSEx.Helpers.LineTerminators.code_points()
+  @media_split_regex ~r/(?<maybe_var_1>\$::)?.+(?<split>:).+(?<maybe_var_2>\$::)|(?<split_2>:)/
 
   defstruct column: 0, acc: [], parenthesis: 0, p_acc: %{}
 
@@ -84,11 +87,14 @@ defmodule CSSEx.Helpers.Media do
           "or"
 
         declaration ->
-          String.split(declaration, ~r/:/, trim: true)
+          String.split(declaration, @media_split_regex, trim: true, on: [:split, :split_2])
           |> Enum.map(fn token ->
             case CSSEx.Helpers.Interpolations.maybe_replace_val(String.trim(token), data) do
-              {:ok, new_token} -> new_token
-              {:error, _} -> raise "#{token} was not declared"
+              {:ok, new_token} ->
+                new_token
+
+              {:error, _} ->
+                raise "#{token} was not declared"
             end
           end)
           |> Enum.join(":")

--- a/lib/helpers/output.ex
+++ b/lib/helpers/output.ex
@@ -1,4 +1,6 @@
 defmodule CSSEx.Helpers.Output do
+  @moduledoc false
+
   @enforce_keys [:data]
   @temp_ext "-cssex.temp"
   defstruct [:data, :to_file, :file_path, valid?: true, acc: []]
@@ -233,7 +235,7 @@ defmodule CSSEx.Helpers.Output do
           :ok ->
             case File.cp("#{file_path}#{@temp_ext}", file_path) do
               :ok ->
-                spawn(fn -> File.rm!("#{file_path}#{@temp_ext}") end)
+                spawn(fn -> File.rm("#{file_path}#{@temp_ext}") end)
                 ctx
 
               error ->

--- a/lib/helpers/selector_chars.ex
+++ b/lib/helpers/selector_chars.ex
@@ -1,4 +1,6 @@
 defmodule CSSEx.Helpers.SelectorChars do
+  @moduledoc false
+
   @white_spaces CSSEx.Helpers.WhiteSpace.code_points()
 
   @appendable_first_char [?., ?#, ?+, ?>, ?~, ?:, ?[, ?| | @white_spaces]

--- a/lib/helpers/white_space.ex
+++ b/lib/helpers/white_space.ex
@@ -1,9 +1,8 @@
 defmodule CSSEx.Helpers.WhiteSpace do
-  @moduledoc """
-  Helpers for matching on white space characters according to Unicode Pattern_White_Space. The chars we match are those mentioned in the wikipedia page except the line terminators that are in the helpers for them since we want to be able to discern line and column when parsing the cssex files
-  https://en.wikipedia.org/wiki/Whitespace_character#Unicode
+  @moduledoc false
 
-  """
+  # https://en.wikipedia.org/wiki/Whitespace_character#Unicode
+
   @white_space_unicode [
                          "\u0009",
                          "\u0020",

--- a/lib/mix/tasks/css.parser.ex
+++ b/lib/mix/tasks/css.parser.ex
@@ -22,6 +22,23 @@ defmodule Mix.Tasks.Cssex.Parser do
 
   --c myapp_web
   """
+
+  @doc """
+  Run the parser with `mix cssex.parser`
+  Required arguments:
+
+  --e /source/path.cssex=/final/path.css
+  --e /source/path.cssex
+  --e source/path.cssex=final/path.css --a yourapp_web
+  --e source/path.cssex --a yourapp_web
+
+  Or
+
+  --c yourapp_web
+
+  Where `yourapp_web` specifies a config under the key CSSEx, with a key of :entry_points composed of tuple pairs of source & destination files.
+
+  """
   def run([]),
     do:
       error(

--- a/lib/structs/hsla.ex
+++ b/lib/structs/hsla.ex
@@ -82,7 +82,7 @@ defmodule CSSEx.HSLA do
         {same, same, same} -> 0
         {n_r, n_g, n_b} when n_r > n_g and n_r > n_b -> (n_g - n_b) / (max - min)
         {n_r, n_g, n_b} when n_g > n_r and n_g > n_b -> 2 + (n_b - n_r) / (max - min)
-        {n_r, n_g, n_b} -> 4 + (n_r - n_g) / (max - min)
+        {n_r, n_g, _n_b} -> 4 + (n_r - n_g) / (max - min)
       end
 
     hue_2 =
@@ -151,10 +151,10 @@ defmodule CSSEx.HSLA do
   def valid_hue_val(n), do: %Unit{value: 0, unit: nil}
 
   def valid_saturation_val(n) when n <= 100 and n >= 0, do: %Unit{value: n, unit: "%"}
-  def valid_saturation_val(n), do: %Unit{value: 0, unit: "%"}
+  def valid_saturation_val(_n), do: %Unit{value: 0, unit: "%"}
 
   def valid_luminance_val(n) when n <= 100 and n >= 0, do: %Unit{value: n, unit: "%"}
-  def valid_luminance_val(n), do: %Unit{value: 0, unit: "%"}
+  def valid_luminance_val(_n), do: %Unit{value: 0, unit: "%"}
 
   def valid_alpha_val(n) when n > 0 and n <= 1, do: n
   def valid_alpha_val(_n), do: 1

--- a/test/ampersand_test.exs
+++ b/test/ampersand_test.exs
@@ -3,7 +3,7 @@ defmodule CSSEx.Ampersand.Test do
   alias CSSEx.Parser
 
   @basic """
-  @!width: 567px;
+  $!width: 567px;
   div{
     color: red;
     &.test {

--- a/test/comment_test.exs
+++ b/test/comment_test.exs
@@ -9,7 +9,7 @@ defmodule CSSEx.Comments.Test do
              "div{color:red}div.test{color:blue}div.test.another-one{color:black;font-family:sans-serif}div .test{color:green}\n"
            } =
              Parser.parse("""
-             @!width: 567px; // comment 0
+             $!width: 567px; // comment 0
              // comment 1
              div{
                color: red;
@@ -35,7 +35,7 @@ defmodule CSSEx.Comments.Test do
              "div{color:red}div.test{color:blue}div.test.another-one{color:black;font-family:sans-serif}div .test{color:green}\n"
            } =
              Parser.parse("""
-             @!width: 567px; /* comment 0
+             $!width: 567px; /* comment 0
              // comment 1
              */
              div{

--- a/test/cssex_test.exs
+++ b/test/cssex_test.exs
@@ -1,3 +1,0 @@
-defmodule CssexTest do
-  use ExUnit.Case, async: true
-end

--- a/test/eex_test.exs
+++ b/test/eex_test.exs
@@ -9,7 +9,7 @@ defmodule CSSEx.EEx.Test do
              ".btn-op-1{background-color:rgba(255,0,0,0.1)}.btn-op-2{background-color:rgba(255,0,0,0.2)}.btn-op-3{background-color:rgba(255,0,0,0.3)}.btn-op-4{background-color:rgba(255,0,0,0.4)}.btn-op-5{background-color:rgba(255,0,0,0.5)}.btn-op-6{background-color:rgba(255,0,0,0.6)}.btn-op-7{background-color:rgba(255,0,0,0.7)}.btn-op-8{background-color:rgba(255,0,0,0.8)}.btn-op-9{background-color:rgba(255,0,0,0.9)}.btn-op-10{background-color:rgba(255,0,0,1.0)}\n"
            } =
              Parser.parse("""
-             @!primary red;
+             $!primary red;
              <%= for n <- 1..10, reduce: "" do
                acc ->
              [acc, ".btn-op-\#{n}", "{",

--- a/test/error_test.exs
+++ b/test/error_test.exs
@@ -2,14 +2,14 @@ defmodule CSSEx.Error.Test do
   use ExUnit.Case, async: true
   alias CSSEx.Parser
 
-  test "non terminating var" do
+  test "non terminating assign" do
     css = """
-    %!width 576px
+    $!width "576px"
     div { color: red; }
     """
 
     assert {:error, %{error: error}} = Parser.parse(css)
-    assert error =~ "invalid :assign declaration at l:1 col:1 to\" :: l:3 c:0"
+    assert error =~ "invalid :variable declaration at l:1 col:1 to\" :: l:1 c:12"
   end
 
   test "invalid parens" do
@@ -45,10 +45,10 @@ defmodule CSSEx.Error.Test do
     assert error =~ "invalid :eex declaration at l:2 col:0 to\" :: l:6 c:0"
   end
 
-  test "assign" do
+  test "variable" do
     css = """
-    @!test 1
-    @!test 2;
+    $!test 1
+    $!test 2;
     """
 
     assert {:error, %{error: error}} = Parser.parse(css)

--- a/test/files/includes/simples/_variables.cssex
+++ b/test/files/includes/simples/_variables.cssex
@@ -1,4 +1,4 @@
-%!screen_breakpoints [
+@!screen_breakpoints [
   sm: "0px",
   md: "768px",
   lg: "992px",
@@ -6,7 +6,7 @@
   xxl: "1440px",
 ];
 
-%!sizes %{
+@!sizes %{
   sm: 12,
   md: 18,
   lg: 24,
@@ -14,25 +14,25 @@
   xxl: 40
 };
 
-%!sizes_props %{
+@!sizes_props %{
   "font-size" => fn(x) -> x end,
   "line-height" => fn(x) -> x end,
   "btn-height" => fn(x) -> Float.round(x * 1.6, 1) end
 };
 
-%!sizes_map for {k, v} <- sizes, reduce: %{} do
+@!sizes_map for {k, v} <- sizes, reduce: %{} do
   acc ->
     Map.put(acc, k, Enum.reduce(sizes_props, %{}, fn({k, fun}, acc_inner) -> Map.put(acc_inner, k, fun.(v)) end))
 end;
 
-%!sides %{left: "l", top: "t", right: "r", bottom: "b"};
+@!sides %{left: "l", top: "t", right: "r", bottom: "b"};
 
 
 /* it reads as {color, inverse, {direction, direction}}, where direction is true or false and means, 
 if it's to darken (true) or lighten (false) the color when applying hover effects and such
 */
 
-%!color_map %{
+@!color_map %{
     white: {"white", "black", {true, false}},
     black: {"black", "white", {false, true}},
     text:  {"#152734", "white", {false, true}},

--- a/test/files/includes/simples/simples.cssex
+++ b/test/files/includes/simples/simples.cssex
@@ -3,15 +3,18 @@
 
 <%= for {name, {color, inverse, _}} <- @color_map, reduce: [] do
   acc ->
-    ["""
-    @*!#{name} #{color};
-    @*!#{name}_inverse #{inverse};
-    """ | acc]
+  [
+    """
+    $*!#{name} #{color};
+    $*!#{name}_inverse #{inverse};
+    """ | acc
+  ]
 end %>
 
 <%= for {k, v} <- @sizes_map, reduce: [] do
   acc ->
-    ["""
+    [
+    """
     .btn-#{k} {
       font-size: #{v["font-size"]}px;
       line-height: #{v["line-height"]}px;
@@ -25,15 +28,16 @@ end %>
   acc ->
     hover_perc = 20;
 
-    ["""
+    [
+    """
     .btn-#{name} {
       border-color: @fn::opacity(#{color}, 0.8);
       background-color: #{color};
       color: #{inverse};
       &:hover {
         border-color: @fn::darken_or_lighten(#{c_dir}, #{color}, #{hover_perc});
-	background-color: @fn::darken_or_lighten(#{c_dir}, #{color}, #{hover_perc});
-	color: @fn::darken_or_lighten(#{i_dir}, #{color}, #{hover_perc});
+    	background-color: @fn::darken_or_lighten(#{c_dir}, #{color}, #{hover_perc});
+    	color: @fn::darken_or_lighten(#{i_dir}, #{color}, #{hover_perc});
       }
     }
 
@@ -55,8 +59,8 @@ end %>
 
       &a {
         &:hover {
-	  color: @fn::darken_or_lighten(#{c_dir}, #{color}, 30);
-	}
+    	  color: @fn::darken_or_lighten(#{c_dir}, #{color}, 30);
+    	}
       }
     }
 
@@ -121,29 +125,31 @@ end %>
 acc_o ->				 
   (for n_2 <- 0..9, rem(n_2, 5) == 0, reduce: acc_o do
     acc	->			
-      ["""
-      .fx-#{n_1}-#{n_2}, .children-fx-#{n_1}-#{n_2} > * {
+	 [
+    """
+    .fx-#{n_1}-#{n_2}, .children-fx-#{n_1}-#{n_2} > * {
+      flex: #{Float.round(n_1 + (n_2 * 0.1), 1)};
+    }
+
+    .fx-#{n_1}#{n_2}, .children-fx-#{n_1}#{n_2} > * {
+      @fn::enforce_size(width, #{n_1}#{n_2}%)
+      flex: 1;
+    }
+    """ | [(
+	for {bp, _width} <- @screen_breakpoints, reduce: [] do
+          acc_i ->
+	      [
+    """
+    @fn::breakpoint_max(#{bp}, @::screen_breakpoints,
+      .#{bp}\:fx-#{n_1}-#{n_2}, .#{bp}\:children-fx-#{n_1}-#{n_2} > * {
         flex: #{Float.round(n_1 + (n_2 * 0.1), 1)};
       }
-
-      .fx-#{n_1}#{n_2}, .children-fx-#{n_1}#{n_2} > * {
+      .#{bp}\:fx-#{n_1}#{n_2}, .#{bp}\:children-fx-#{n_1}#{n_2} > * {
         @fn::enforce_size(width, #{n_1}#{n_2}%)
-	flex: 1;
+      	flex: 1;
       }
-      """ | [(
-	for {bp, width} <- @screen_breakpoints, reduce: [] do
-          acc_i ->
-	    ["""
-	    @fn::breakpoint_max(#{bp}, %::screen_breakpoints,
-	      .#{bp}\:fx-#{n_1}-#{n_2}, .#{bp}\:children-fx-#{n_1}-#{n_2} > * {
-	        flex: #{Float.round(n_1 + (n_2 * 0.1), 1)};
-	      }
-	      .#{bp}\:fx-#{n_1}#{n_2}, .#{bp}\:children-fx-#{n_1}#{n_2} > * {
-	        @fn::enforce_size(width, #{n_1}#{n_2}%)
-		flex: 1;
-	      }
-	    )
-	    """	| acc_i]					  
+    )
+    """	| acc_i]					  
         end
      ) | acc]]
   end)
@@ -153,15 +159,16 @@ end %>
     @fn::enforce_size(width, 100%)
 }
 
-<%= for {bp, width} <- @screen_breakpoints, reduce: [] do
+<%= for {bp, _width} <- @screen_breakpoints, reduce: [] do
 acc ->
-  ["""						       
-   @fn::breakpoint_max(#{bp}, %::screen_breakpoints,
-     .#{bp}\:fx-100, .#{bp}\:children-fx-100 > * {
-       @fn::enforce_size(width, 100%)
-     }
-   )  	 
-  """ | acc]						       
+    [
+    """						       
+    @fn::breakpoint_max(#{bp}, @::screen_breakpoints,
+      .#{bp}\:fx-100, .#{bp}\:children-fx-100 > * {
+        @fn::enforce_size(width, 100%)
+      }
+    )	 
+    """ | acc]						       
 end %>
 
 <%= for n_1 <- 0..10, reduce: [] do
@@ -170,70 +177,74 @@ acc_o ->
   [(for {side, short} <- @sides, reduce: [] do
         acc ->						   
 	
-	  ["""
-      	  .m#{short}-#{n_1}, .children-m#{short}-#{n_1} > * {
-	    margin-#{side}: #{round(n_1 * 10)}px;
-	  }
+	  [
+    """
+    .m#{short}-#{n_1}, .children-m#{short}-#{n_1} > * {
+      margin-#{side}: #{round(n_1 * 10)}px;
+    }
 
-	  .p#{short}-#{n_1}, .children-p#{short}-#{n_1} > * {
-	    padding-#{side}: #{round(n_1 * 10)}px;
-	  }
-          """, (
-            for {bp, width} <- @screen_breakpoints, reduce: [] do
-               acc_bp ->
-	         ["""
-		 @fn::breakpoint_max(bp, %::screen_breakpoints, 
-		   .#{bp}\:m#{short}-#{n_1}, .#{bp}\:children-m#{short}-#{n_1} > * {
-		     margin-#{side}: #{round(n_1 * 10)}px !important;
-		   }
+    .p#{short}-#{n_1}, .children-p#{short}-#{n_1} > * {
+      padding-#{side}: #{round(n_1 * 10)}px;
+    }
+    """, (
+      for {bp, _width} <- @screen_breakpoints, reduce: [] do
+        acc_bp ->
+	  [
+    """
+    @fn::breakpoint_max(bp, @::screen_breakpoints, 
+      .#{bp}\:m#{short}-#{n_1}, .#{bp}\:children-m#{short}-#{n_1} > * {
+        margin-#{side}: #{round(n_1 * 10)}px !important;
+      }
+    
+      .#{bp}\:p#{short}-#{n_1}, .#{bp}\:children-p#{short}-#{n_1} > * {
+        padding-#{side}: #{round(n_1 * 10)}px !important;
+      }
+    )
+    """ | acc_bp]
+      end
+    ) | acc]
+    end) | [
+    """
+    .mx-#{n_1}, .children-mx-#{n_1} {
+      margin-left: #{round(n_1 * 10)}px;
+      margin-right: #{round(n_1 * 10)}px;
+    }
 
-		   .#{bp}\:p#{short}-#{n_1}, .#{bp}\:children-p#{short}-#{n_1} > * {
-		     padding-#{side}: #{round(n_1 * 10)}px !important;
-		   }
-		 )
-		 """ | acc_bp]
-	    end
-	 ) | acc]
-     end) | ["""
-     .mx-#{n_1}, .children-mx-#{n_1} {
-       margin-left: #{round(n_1 * 10)}px;
-       margin-right: #{round(n_1 * 10)}px;
-     }
+    .my-#{n_1}, .children-my-#{n_1} {
+      margin-top: #{round(n_1 * 10)}px;
+      margin-bottom: #{round(n_1 * 10)}px;
+    }
 
-     .my-#{n_1}, .children-my-#{n_1} {
-       margin-top: #{round(n_1 * 10)}px;
-       margin-bottom: #{round(n_1 * 10)}px;
-     }
+    .m-#{n_1}, .children-m-#{n_1} {
+      margin: #{round(n_1 * 10)}px;
+    }
 
-     .m-#{n_1}, .children-m-#{n_1} {
-       margin: #{round(n_1 * 10)}px;
-     }
+    .px-#{n_1}, .children-px-#{n_1} {
+      padding-left: #{round(n_1 * 10)}px;
+      padding-right: #{round(n_1 * 10)}px;
+    }
 
-     .px-#{n_1}, .children-px-#{n_1} {
-       padding-left: #{round(n_1 * 10)}px;
-       padding-right: #{round(n_1 * 10)}px;
-     }
+    .py-#{n_1}, .children-py-#{n_1} {
+      padding-top: #{round(n_1 * 10)}px;
+      padding-bottom: #{round(n_1 * 10)}px;
+    }
 
-     .py-#{n_1}, .children-py-#{n_1} {
-       padding-top: #{round(n_1 * 10)}px;
-       padding-bottom: #{round(n_1 * 10)}px;
-     }
-
-     .p-#{n_1}, .children-p-#{n_1} {
-       padding: #{round(n_1 * 10)}px;
-     }
-     """ | acc_o]]				       
+    .p-#{n_1}, .children-p-#{n_1} {
+      padding: #{round(n_1 * 10)}px;
+    }
+    """ | acc_o]]				       
 end %>
 
-<%= for {bp, width} <- @screen_breakpoints, reduce: [] do
+<%= for {bp, _width} <- @screen_breakpoints, reduce: [] do
 acc ->
-  ["""
-   @fn::breakpoint_max(#{bp}, %::screen_breakpoints,
-     .#{bp}\:fx-100, .#{bp}\:children-fx-100 > * {
-       @fn::enforce_size(width, 100%)
-     }
-   )
-  """ | acc]						       
+    [
+    """
+    @fn::breakpoint_max(#{bp}, @::screen_breakpoints,
+      .#{bp}\:fx-100, .#{bp}\:children-fx-100 > * {
+        @fn::enforce_size(width, 100%)
+      }
+    )
+    """ | acc]						       
 end %>
 
 <%= for n_1 <- 0..10, reduce: [] do
@@ -241,45 +252,45 @@ acc_o ->
   for {bp, _width} <- @screen_breakpoints, reduce: acc_o do
     acc ->
     [
-	"""       
-        @fn::breakpoint_max(#{bp}, %::screen_breakpoints,
-          .#{bp}\:mx-#{n_1}, .#{bp}\:children-mx-#{n_1} > * {
-            margin-left: #{round(n_1 * 10)}px !important;
-            margin-right: #{round(n_1 * 10)}px !important;
-           }
-           .#{bp}\:my-#{n_1}, .#{bp}\:children-my-#{n_1} > * {
-              margin-top: #{round(n_1 * 10)}px !important;
-              margin-bottom: #{round(n_1 * 10)}px !important;
-           }
-           .#{bp}\:m-#{n_1}, .#{bp}\:children-m-#{n_1} > * {
-              margin: #{round(n_1 * 10)}px !important;
-           }
-           .#{bp}\:px-#{n_1}, .#{bp}\:children-px-#{n_1} > * {
-            padding-left: #{round(n_1 * 10)}px !important;
-            padding-right: #{round(n_1 * 10)}px !important;
-           }
-           .#{bp}\:py-#{n_1}, .#{bp}\:children-py-#{n_1} > * {
-              padding-top: #{round(n_1 * 10)}px !important;
-              padding-bottom: #{round(n_1 * 10)}px !important;
-           }
-           .#{bp}\:p-#{n_1}, .#{bp}\:children-p-#{n_1} > * {
-              padding: #{round(n_1 * 10)}px !important;
-           }
-           .#{bp}\:fx-row, .#{bp}\:children-fx-row > * {
-             display: flex !important;
-             flex-flow: row wrap !important;
-             width: 100% !important;
-           }
-           .#{bp}\:fx-nowrap, .#{bp}\:children-fx-nowrap > * {
-             flex-wrap: nowrap !important;
-           }
-           .#{bp}\:fx-column, .#{bp}\:children-fx-column > * {
-             display: flex !important;
-             flex-flow: column nowrap !important;
-             width: 100% !important;
-           }
-        )
-        """ | acc
+    """       
+    @fn::breakpoint_max(#{bp}, @::screen_breakpoints,
+      .#{bp}\:mx-#{n_1}, .#{bp}\:children-mx-#{n_1} > * {
+        margin-left: #{round(n_1 * 10)}px !important;
+        margin-right: #{round(n_1 * 10)}px !important;
+      }
+      .#{bp}\:my-#{n_1}, .#{bp}\:children-my-#{n_1} > * {
+        margin-top: #{round(n_1 * 10)}px !important;
+        margin-bottom: #{round(n_1 * 10)}px !important;
+      }
+      .#{bp}\:m-#{n_1}, .#{bp}\:children-m-#{n_1} > * {
+        margin: #{round(n_1 * 10)}px !important;
+      }
+      .#{bp}\:px-#{n_1}, .#{bp}\:children-px-#{n_1} > * {
+        padding-left: #{round(n_1 * 10)}px !important;
+        padding-right: #{round(n_1 * 10)}px !important;
+      }
+      .#{bp}\:py-#{n_1}, .#{bp}\:children-py-#{n_1} > * {
+        padding-top: #{round(n_1 * 10)}px !important;
+        padding-bottom: #{round(n_1 * 10)}px !important;
+      }
+      .#{bp}\:p-#{n_1}, .#{bp}\:children-p-#{n_1} > * {
+        padding: #{round(n_1 * 10)}px !important;
+      }
+      .#{bp}\:fx-row, .#{bp}\:children-fx-row > * {
+        display: flex !important;
+        flex-flow: row wrap !important;
+        width: 100% !important;
+      }
+      .#{bp}\:fx-nowrap, .#{bp}\:children-fx-nowrap > * {
+        flex-wrap: nowrap !important;
+      }
+      .#{bp}\:fx-column, .#{bp}\:children-fx-column > * {
+        display: flex !important;
+        flex-flow: column nowrap !important;
+        width: 100% !important;
+      }
+      )
+    """ | acc
     ]
     end
 end %>
@@ -354,17 +365,17 @@ end %>
 }
 
 
-<%= for {side, short} <- @sides, reduce: [] do
+<%= for {side, _short} <- @sides, reduce: [] do
  acc ->
    [
      """
      .text-#{side} { text-laign: #{side}; } 
      """
-     | (for {bp, width} <- @screen_breakpoints, reduce: acc do
+     | (for {bp, _width} <- @screen_breakpoints, reduce: acc do
           acc_bp ->
             [
               """
-              @fn::breakpoint_max(bp, %::screen_breakpoints, 
+              @fn::breakpoint_max(bp, @::screen_breakpoints, 
                 .#{bp}\:text-#{side} { text-align: #{side}; }
               )
               """ | acc_bp]
@@ -373,7 +384,7 @@ end %>
 end %>
 
 
-<%= for {bp, width} <- @screen_breakpoints, reduce: [] do
+<%= for {bp, _width} <- @screen_breakpoints, reduce: [] do
   acc ->
     [
 	"""

--- a/test/files/non_existing/test_1.css
+++ b/test/files/non_existing/test_1.css
@@ -1,1 +1,0 @@
-.write{color:red}

--- a/test/files/non_existing/test_1.cssex
+++ b/test/files/non_existing/test_1.cssex
@@ -1,1 +1,0 @@
-.write{color:red}

--- a/test/files/originals_templates/include_1.cssex
+++ b/test/files/originals_templates/include_1.cssex
@@ -1,4 +1,4 @@
-@!primary purple;
+$!primary purple;
 @include ../originals_relative/include_2.cssex;
 div {
     color: white;

--- a/test/files/originals_templates/test_1.cssex
+++ b/test/files/originals_templates/test_1.cssex
@@ -1,4 +1,4 @@
-%!var %{
+@!var %{
   test_1: %{
     "color" => "#ffffff",
     "background-color" => "#000000"

--- a/test/files/task/original_2.cssex
+++ b/test/files/task/original_2.cssex
@@ -1,4 +1,4 @@
-@!color blue;
+$!color blue;
 
 div {
     &.test {

--- a/test/function_test.exs
+++ b/test/function_test.exs
@@ -19,7 +19,7 @@ defmodule CSSEx.Function.Test do
     {:ok, %CSSEx.HSLA{hsla | l: %CSSEx.Unit{l_unit | value: new_l}} |> to_string}
   end;
 
-  @!red red;
+  $!red red;
   .test{color: @fn::lighten_test(<$red$>, 10)}
   .test{color: @fn::lighten_test(#fdf, 10);}
   """
@@ -39,7 +39,7 @@ defmodule CSSEx.Function.Test do
              "div{color:hsla(0,100%,60%,1.0)}\n"
            } =
              Parser.parse("""
-             @!test @fn::lighten(red, 10);
+             $!test @fn::lighten(red, 10);
              div { color: <$test$>;}
              """)
   end
@@ -51,7 +51,7 @@ defmodule CSSEx.Function.Test do
              "div{color:hsla(0,100%,40%,1.0)}\n"
            } =
              Parser.parse("""
-             @!test @fn::darken(red, 10);
+             $!test @fn::darken(red, 10);
              div { color: <$test$>;}
              """)
   end
@@ -63,7 +63,7 @@ defmodule CSSEx.Function.Test do
              "div{color:rgba(255,0,0,0.6)}\n"
            } =
              Parser.parse("""
-             @!test @fn::opacity(red, 0.6);
+             $!test @fn::opacity(red, 0.6);
              div { color: <$test$>;}
              """)
   end
@@ -71,7 +71,7 @@ defmodule CSSEx.Function.Test do
   test "function errors result in parsing errors" do
     assert {:error, %Parser{error: error}} =
              Parser.parse("""
-             @!test @fn::opacity(red);
+             $!test @fn::opacity(red);
              div { color: <$test$>;}
              """)
 

--- a/test/import_test.exs
+++ b/test/import_test.exs
@@ -3,7 +3,7 @@ defmodule CSSEx.Import.Test do
   alias CSSEx.Parser
 
   @basic """
-  @!width 567px;
+  $!width 567px;
   @charset "UTF-8";
   @import "test.css";
   @import url("/other.css") print;

--- a/test/include_test.exs
+++ b/test/include_test.exs
@@ -23,9 +23,8 @@ defmodule CSSEx.Include.Test do
 
   test "parsing simples", %{
     base_path: base_path,
-    original_file: original_file,
-    final_file: final_file
+    original_file: original_file
   } do
-    assert {:ok, _, result} = Parser.parse_file(base_path, original_file)
+    assert {:ok, _, _result} = Parser.parse_file(base_path, original_file)
   end
 end

--- a/test/media_test.exs
+++ b/test/media_test.exs
@@ -32,9 +32,9 @@ defmodule CSSEx.Media.Test do
     assert {:ok, _,
             "@media print and (max-width:565px and min-width:300px), (min-width:565px){.test{color:blue}}\n"} =
              Parser.parse("""
-             @!max-width 565px;
+             $!max-width 565px;
              .test {
-               @media print and (max-width: @$$max-width and min-width: 300px), (min-width: @$$max-width) {
+               @media print and (max-width: $::max-width and min-width: 300px), (min-width: $::max-width) {
                  color: blue;
                }
              }
@@ -45,8 +45,8 @@ defmodule CSSEx.Media.Test do
     assert {:ok, _,
             "@media print and (max-width:565px){.test{color:red}}@media print and (max-width:565px) and (min-width:300px){.test.inner{color:blue}.test{color:orange}}\n"} =
              Parser.parse("""
-             @!color orange;
-             @!min_width 300px;
+             $!color orange;
+             $!min_width 300px;
              @media print and (max-width: 565px) {
                .test { color: red;
              	@media and (min-width: <$min_width$>) {

--- a/test/nesting_test.exs
+++ b/test/nesting_test.exs
@@ -103,4 +103,22 @@ defmodule CSSEx.Nesting.Test do
              }
              """)
   end
+
+  test "nesting multiple combinations" do
+    assert {
+             :ok,
+             _,
+             "div.concat .inner,.parent div .inner,section.concat .inner,.parent section .inner{color:blue}div.concat.inner-concat,.parent.inner-concat div,section.concat.inner-concat,.parent.inner-concat section{color:red}\n"
+           } =
+             Parser.parse("""
+             div, section {
+
+                &.concat, .parent& {
+
+                   .inner { color: blue; }
+                   &.inner-concat { color: red; }
+                }
+             }  
+             """)
+  end
 end

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -6,7 +6,7 @@ defmodule CSSEx.Parser.Test do
     {
       "basic variable replacement",
       """
-      @!test 16px;
+      $!test 16px;
 
       div { width: <$test$>; }
       """,
@@ -17,7 +17,7 @@ defmodule CSSEx.Parser.Test do
     {
       "variable replacement and root placing of css var",
       """
-      @*!test 16px;
+      $*!test 16px;
 
       div {
          width: <$test$>;
@@ -31,7 +31,7 @@ defmodule CSSEx.Parser.Test do
     {
       "assigns work correctly",
       """
-      %!test %{
+      @!test %{
         test_1: :b,
         test_2: 1
       };
@@ -42,7 +42,7 @@ defmodule CSSEx.Parser.Test do
     {
       "assigns can be used in eex blocks",
       """
-      %!var %{
+      @!var %{
         test_1: %{
       	  "color" => "#ffffff",
       	  "background-color" => "#000000"
@@ -74,7 +74,7 @@ defmodule CSSEx.Parser.Test do
     {
       "interpolation works in attributes",
       """
-      @!test px;
+      $!test px;
 
       div {
         border: 2<$test$> solid red;
@@ -85,7 +85,7 @@ defmodule CSSEx.Parser.Test do
     {
       "interpolation works in rules and other non-attributes",
       """
-      @!test sm;
+      $!test sm;
       div.<$test$>{border:2px solid red;
       }
       """,


### PR DESCRIPTION
Fixed nesting error when using pre concat inside a post concat that sometimes would bork the chain by generating `.class_1&.class_2` where class_2 was concatenated before class so it no longer would evaluate true for when checking if it should concatenate outside the parent.

Remodeled the variables & assigns.
Variables where using the `@!` to be declared while elixir assigns where using `%!` which was confusing since then inside elixir blocks you could only refer to assigns and those would be using elixir's `@` syntax. 
So now assigns use `@!` to be declared, `@::`  to be interpolated in function heads and `@` inside eex blocks.

CSSEx Variables instead of being `%` changed to the `$`, which makes it closer to SCSS.
So now they're used as `$!` to declare, `<$interpolate$>` or `$::`.

Fixed warnings on tests and lib

Fixed docs

Improved the readme file

Add unused call by default to ctx_content inside the compiled function body to remove warnings