### PR TITLE
Refactored the file watcher should now work 100% and take care of rem…

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Its main purpose is to provide a native Elixir pre-processor for CSS, in the vei
 ### Syntax:
 
 <ul>
-  <li><a href="#selectors">Selectors</a><li>  
+  <li><a href="#selectors">Selectors</a></li>
   <li><a href="#variables">Variables</a></li>
   <li><a href="#assigns">Assigns</a></li>
   <li><a href="#functions">Functions</a></li>

--- a/lib/helpers/function.ex
+++ b/lib/helpers/function.ex
@@ -4,11 +4,9 @@ defmodule CSSEx.Helpers.Function do
   import CSSEx.Helpers.Shared,
     only: [
       inc_col: 1,
-      inc_col: 2,
       inc_line: 1,
-      inc_line: 2,
-      calc_line_offset: 2,
-      file_and_line_opts: 1
+      file_and_line_opts: 1,
+      inc_no_count: 1
     ]
 
   import CSSEx.Parser, only: [add_error: 2]
@@ -38,12 +36,8 @@ defmodule CSSEx.Helpers.Function do
 
       {fun_result, _} = Code.eval_string(full_string, [], file_and_line_opts(data))
 
-      line_correction = calc_line_offset(1, fun_string)
-
       new_data =
         data
-        |> inc_col(2)
-        |> inc_line(line_correction)
         |> add_fun(name, fun_result)
 
       {:ok, {new_data, rem}}
@@ -180,15 +174,12 @@ defmodule CSSEx.Helpers.Function do
   end
 
   def finish_call(data, rem, result) when is_binary(result) do
-    line_correction = calc_line_offset(0, result)
-
     data
-    |> inc_line(line_correction)
     |> finish_call(rem, to_charlist(result))
   end
 
   def finish_call(data, rem, result) when is_list(result) do
-    {:ok, {data, :lists.flatten([result | rem])}}
+    {:ok, {inc_no_count(data), :lists.flatten([result, ?$, 0, ?$, 0, ?$ | rem])}}
   end
 
   def finish_error(data, error),

--- a/lib/helpers/shared.ex
+++ b/lib/helpers/shared.ex
@@ -6,12 +6,30 @@ defmodule CSSEx.Helpers.Shared do
   @line_terminators CSSEx.Helpers.LineTerminators.code_points()
 
   # increment the column token count
-  def inc_col(%{column: column} = data, amount \\ 1),
+  def inc_col(data, amount \\ 1)
+
+  def inc_col(%{column: column, no_count: 0} = data, amount),
     do: %{data | column: column + amount}
 
+  def inc_col(data, _), do: data
+
   # increment the line and reset the column
-  def inc_line(%{line: line} = data, amount \\ 1),
+  def inc_line(data, amount \\ 1)
+
+  def inc_line(%{line: line, no_count: 0} = data, amount),
     do: %{data | column: 0, line: line + amount}
+
+  def inc_line(data, _), do: data
+
+  def inc_no_count(%{no_count: no_count} = data, amount \\ 1) do
+    new_count =
+      case no_count + amount do
+        n when n >= 0 -> n
+        _ -> 0
+      end
+
+    %{data | no_count: new_count}
+  end
 
   def generate_prefix(%{current_chain: cc, prefix: nil}), do: cc
   def generate_prefix(%{current_chain: cc, prefix: prefix}), do: prefix ++ cc

--- a/test/file_test.exs
+++ b/test/file_test.exs
@@ -36,6 +36,7 @@ defmodule CSSEx.File.Test do
       assert {:ok, _} = File.rm_rf(final_base)
       assert {:ok, _} = File.rm_rf(target_originals)
       assert {:ok, _} = File.rm_rf(target_originals_relative)
+      assert {:ok, _} = File.rm_rf(non_existing_path)
     end)
 
     {:ok, %{target_originals: target_originals, non_existing: non_existing_path}}

--- a/test/files/non_existing/test_1.css
+++ b/test/files/non_existing/test_1.css
@@ -1,1 +1,0 @@
-.write{color:red}

--- a/test/files/non_existing/test_1.cssex
+++ b/test/files/non_existing/test_1.cssex
@@ -1,1 +1,0 @@
-.write{color:red}


### PR DESCRIPTION
Refactored the file watcher should now work 100% and take care of removing dependencies that are removed from stylesheets while running

Added buffering to the file watcher

Fixed the line reporting issues, one place is still adding further l:c: information to the error msg but the correct line is displayed as well

Fixed race condition due to the naming of the temporary file while parsing directly into a file by adding a random string, but at the same time, with buffering on the watcher it shouldn't happen anyway

Typo on the readme.md

Fixed the two last test files that weren't being cleaned up on exiting