### PR TITLE
Expandable apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,6 +718,8 @@ $()
 $*()
 $::
 @include
+@expandable
+@apply
 @fn
 <% ....
 <$ ....
@@ -743,10 +745,10 @@ And `../shared/samples.cssex`:
 
 ```css
 $()tag div
-#{tag} { background-color: white; color: orange; }
+<$tag$> { background-color: white; color: orange; }
 ```
 
-The final output will always have `div` declared first, and duplicate attributes will hold the value according to the declaration order:
+The final output will always have `div` declared first, and duplicate attributes will hold the value according to their declaration order. Since the last evaluated `div` selector set the color to `orange` that's the color that the final stylesheet will hold:
 
 ```css
 div {background-color: white, color: orange }
@@ -761,7 +763,7 @@ div { color: green; }
 div { background-color: white, color: orange }
 ```
 
-This means it can condense the final output. And also that it's ok to `@apply` multiple `@expandable` classes to an element as any repeated attributes are just replaced.
+This means it can condense the final output, and also that it's ok to `@apply` multiple `@expandable` classes to an element as any repeated attributes are just replaced, or define selectors with repeated attributes in different places as they coalesce into a single representations.
 
 If you want multiple declarations to not be merged right now the only possibility is to have different entry points that produce plain css files and use them with regular `@import` rules on a final css. 
 

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ It has to be terminated with semicolon followed by newline.
 
 #### @expandable & @apply
 
-Expandables allow you to define utility classes that can be used inside any selector to add attributes & or selectors. It allows for then `@apply`ing those blocks in different ways. You can force the `@apply` to be exactly as it was resolved when declared and keep the selector hierarchies there defined in reference to the `@expandable` selector, you can use it to be dynamically evaluated, or to apply it's hierarchies in the new context while using any variable interpolation as it occurred when defining. It might sound confusing but with an example is easier to see
+Expandables allow you to define utility classes that can be used inside any selector to add attributes & or selectors. It allows for then `@apply`ing those blocks in different ways. You can force the `@apply` to be exactly as it was resolved when declared and keep the selector hierarchies there defined in reference to the `@expandable` selector, you can use it to be dynamically evaluated, or to apply its hierarchies in the new context while using any variable interpolation as it occurred when defining. It might sound confusing but with an example is easier to see
 
 ```scss
 $!color red;
@@ -335,23 +335,23 @@ $!color blue;
 ##### into
 
 ```css
-.hoverable{
+.hoverable {
   color:red
 }
 
-.hoverable:hover{
+.hoverable:hover {
   color:rgba(204,0,0,1.0)
 }
 
-container .hoverable{
+container .hoverable {
   background-color:black
 }
 
-.class-1{
+.class-1 {
   color:red
 }
 
-.class-1:hover{
+.class-1:hover {
   color:rgba(204,0,0,1.0)
 }
 
@@ -396,34 +396,34 @@ container .class-4 {
 }
 ```
 
-As you can see, the we had a variable `$!color` declared with the value `red`.
+As you can see, we had a variable `$!color` declared with the value `red`.
 Then we declared an `@expandable` block for the selector `.hoverable`, where we used interpolation for `color`, and had nesting selectors, one of which calling a function again with an interpolated value.
 
 That is the top level declarations that came on top of the stylesheet:
 
 ```css
-.hoverable{
+.hoverable {
   color:red
 }
 
-.hoverable:hover{
+.hoverable:hover {
   color:rgba(204,0,0,1.0)
 }
 
-container .hoverable{
+container .hoverable {
   background-color:black
 }
 ```
-Then we declared a `.class-1` selector and applied the `hoverable` element we declared as `@expandable` before inside it (notice how we don't user the `.` before its name.
+Then we declared a `.class-1` selector and applied the `hoverable` element we declared as `@expandable` before inside it (notice we don't use the `.` before its name).
 
-What this did was apply all the contents of that expandable element inside ours. You can see that the nesting `&` where applied to `.class-1`:
+What this did was apply all the contents of that expandable element inside `.class-1`. You can see that the nesting `&` where applied to `.class-1`:
 
 ```css
-.class-1{
+.class-1 {
   color:red
 }
 
-.class-1:hover{
+.class-1:hover {
   color:rgba(204,0,0,1.0)
 }
 
@@ -465,7 +465,7 @@ container .class-3 {
 }
 ```
 
-Lastly we did the same original non-prefix `@apply` in `.class-4` and in this case, the value of the variables used was the ones set at declaration time, `red`, but the nesting was still applied in terms of the current selector:
+Lastly we did the same original non-prefix `@apply` in `.class-4` and in this case, the value of the variables used were the ones set at declaration time, `red`, but the nesting was still applied in terms of the current selector:
 
 ```css
 .class-4 {
@@ -489,13 +489,13 @@ You can also string together several elements to expand in a single `@apply`, wi
 
 The `@expandable` directives  are placed in order of declaration at the top of the final stylesheet as individual selectors, but you can declare them from any file or part of the file as long as it's not inside a block, they must always be declared on a top level.
 
-The only exception on their placement is when using `@media` selectors inside `@expandable`. In those cases normal rules will go to the top but the media parts will be placed alongside the other media statements
+The only exception on their final placement is when using `@media` selectors inside `@expandable`. In those cases normal rules will go to the top but the media parts will be placed alongside the other media statements.
 
-The `@apply` directive takes a list of white-space separated tokens, where each token refers to a previously declared `@expandable` block. You should not use the `.` of the original to refer to them. You can additionally define their expansion mode with `?` (all elements dynamically evaluated) or `!` (as a static block as evaluated when declared). The default without prefix is a mix of both, variables with the values at the time of declaration and nesting dynamically evaluated inside the context of the block the `@apply` is declared in.
+The `@apply` directive takes a list of white-space separated tokens, where each token refers to a previously declared `@expandable` block. You should not use the `.` of the original class to refer to them. You can additionally define their expansion mode with `?` (all elements dynamically evaluated) or `!` (as a static block as evaluated when declared). The default without prefix is a mix of both, variables with the values at the time of declaration and nesting dynamically evaluated inside the context of the block the `@apply` is declared in.
 
-Keep note that `<$ ... $>` interpolation is the only consistent form of interpolation. If you use, for instance in `@fn::...` call the form `$::color`, this will always be dynamically evaluated. EEx blocks follow the same pattern, if you want them to be the value at declaration you need to use the `!` prefix when `@apply`ing.
+Keep note that `<$ ... $>` interpolation is the only consistent form of interpolation. If you use, for instance in `@fn::...` call the form `$::color`, this will always be dynamically evaluated. EEx blocks follow the same pattern, if you want them to be expanded as they resolved at declaration you need to use the `!` prefix when `@apply`ing.
 
-Note that you can also declare `@media` attributes inside `@expandables` and nest them as well.
+Note that you can also declare `@media` attributes inside `@expandables` and nest them as well. Most times you'll want to use normal applying or `?`.
 
 
 <div id="functions"></>

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Its main purpose is to provide a native Elixir pre-processor for CSS, in the vei
   <li><a href="#selectors">Selectors</a></li>
   <li><a href="#variables">Variables</a></li>
   <li><a href="#assigns">Assigns</a></li>
+  <li><a href="#expandable_apply">@expandable & @apply</a></li>
   <li><a href="#functions">Functions</a></li>
   <li><a href="#implemented_functions">Implemented Functions</a></li>
   <li><a href="#eex">EEx Blocks</a></li>
@@ -293,6 +294,209 @@ The declaration form is:
 
 It has to be terminated with semicolon followed by newline.
 
+<div id="expandable_apply"></div>
+
+#### @expandable & @apply
+
+Expandables allow you to define utility classes that can be used inside any selector to add attributes & or selectors. It allows for then `@apply`ing those blocks in different ways. You can force the `@apply` to be exactly as it was resolved when declared and keep the selector hierarchies there defined in reference to the `@expandable` selector, you can use it to be dynamically evaluated, or to apply it's hierarchies in the new context while using any variable interpolation as it occurred when defining. It might sound confusing but with an example is easier to see
+
+```scss
+$!color red;
+
+@expandable .hoverable {
+  color: <$color$>;
+  &:hover {
+    color: @fn::darken(<$color$>, 10);
+  }
+  container& {
+    background-color: black;
+  }
+}
+
+.class-1 {
+  @apply hoverable;
+}
+
+$!color blue;
+
+.class-2 {
+  @apply !hoverable;
+}
+
+.class-3 {
+  @apply ?hoverable;
+}
+
+.class-4 {
+  @apply hoverable;
+}
+```
+
+##### into
+
+```css
+.hoverable{
+  color:red
+}
+
+.hoverable:hover{
+  color:rgba(204,0,0,1.0)
+}
+
+container .hoverable{
+  background-color:black
+}
+
+.class-1{
+  color:red
+}
+
+.class-1:hover{
+  color:rgba(204,0,0,1.0)
+}
+
+container .class-1 {
+  background-color:black
+}
+
+.class-2 {
+  color:red
+}
+
+.class-2 .hoverable:hover {
+  color:rgba(204,0,0,1.0)
+}
+
+.class-2 container .hoverable {
+  background-color:black
+}
+
+.class-3 {
+  color:blue
+}
+
+.class-3:hover {
+  color:rgba(0,204,0,1.0)
+}
+
+container .class-3 {
+  background-color:black
+}
+
+.class-4 {
+  color:red
+}
+
+.class-4:hover {
+  color:rgba(204,0,0,1.0)
+}
+
+container .class-4 {
+  background-color:black
+}
+```
+
+As you can see, the we had a variable `$!color` declared with the value `red`.
+Then we declared an `@expandable` block for the selector `.hoverable`, where we used interpolation for `color`, and had nesting selectors, one of which calling a function again with an interpolated value.
+
+That is the top level declarations that came on top of the stylesheet:
+
+```css
+.hoverable{
+  color:red
+}
+
+.hoverable:hover{
+  color:rgba(204,0,0,1.0)
+}
+
+container .hoverable{
+  background-color:black
+}
+```
+Then we declared a `.class-1` selector and applied the `hoverable` element we declared as `@expandable` before inside it (notice how we don't user the `.` before its name.
+
+What this did was apply all the contents of that expandable element inside ours. You can see that the nesting `&` where applied to `.class-1`:
+
+```css
+.class-1{
+  color:red
+}
+
+.class-1:hover{
+  color:rgba(204,0,0,1.0)
+}
+
+container .class-1 {
+  background-color:black
+}
+```
+
+Then we overwrote the `color` variable with the value `blue`.
+On `.class-2` we did the same as in `.class-1` but this time we prepended the name with `!`. This forces the expandable element to be inserted with the interpolation it had when evaluated originally and also with the nesting referring to the original `.hoverable` selector:
+
+```css
+.class-2 {
+  color:red
+}
+
+.class-2 .hoverable:hover {
+  color:rgba(204,0,0,1.0)
+}
+
+.class-2 container .hoverable {
+  background-color:black
+}
+```
+
+On `.class-3` we did the same, but now prepended the expandable identifier with `?`. This made it be dynamically evaluated, both interpolation and nesting. You can see the color being blue and the result of `@fn::darken` being blue as well:
+
+```css
+.class-3 {
+  color:blue
+}
+
+.class-3:hover {
+  color:rgba(0,204,0,1.0)
+}
+
+container .class-3 {
+  background-color:black
+}
+```
+
+Lastly we did the same original non-prefix `@apply` in `.class-4` and in this case, the value of the variables used was the ones set at declaration time, `red`, but the nesting was still applied in terms of the current selector:
+
+```css
+.class-4 {
+  color:red
+}
+
+.class-4:hover {
+  color:rgba(204,0,0,1.0)
+}
+
+container .class-4 {
+  background-color:black
+}
+```
+
+You can also string together several elements to expand in a single `@apply`, with different evaluation scopes as well. The order of declaration is the order the attributes will be set.
+
+`@apply one-expandable ?another-expandable !a-different-one;`
+
+`@expandable` declarations specify a **single** class selector (e.g. `.class`) followed by a block `{ ... }`.
+
+The `@expandable` directives  are placed in order of declaration at the top of the final stylesheet as individual selectors, but you can declare them from any file or part of the file as long as it's not inside a block, they must always be declared on a top level.
+
+The only exception on their placement is when using `@media` selectors inside `@expandable`. In those cases normal rules will go to the top but the media parts will be placed alongside the other media statements
+
+The `@apply` directive takes a list of white-space separated tokens, where each token refers to a previously declared `@expandable` block. You should not use the `.` of the original to refer to them. You can additionally define their expansion mode with `?` (all elements dynamically evaluated) or `!` (as a static block as evaluated when declared). The default without prefix is a mix of both, variables with the values at the time of declaration and nesting dynamically evaluated inside the context of the block the `@apply` is declared in.
+
+Keep note that `<$ ... $>` interpolation is the only consistent form of interpolation. If you use, for instance in `@fn::...` call the form `$::color`, this will always be dynamically evaluated. EEx blocks follow the same pattern, if you want them to be the value at declaration you need to use the `!` prefix when `@apply`ing.
+
+Note that you can also declare `@media` attributes inside `@expandables` and nest them as well.
+
 
 <div id="functions"></>
 
@@ -542,10 +746,10 @@ $()tag div
 #{tag} { background-color: white; color: orange; }
 ```
 
-The final output will always have `div` declared first, and the attributes in their declaration order:
+The final output will always have `div` declared first, and duplicate attributes will hold the value according to the declaration order:
 
 ```css
-div { color: green; background-color: white, color: orange }
+div {background-color: white, color: orange }
 .sample { color: red }
 ```
 
@@ -557,20 +761,22 @@ div { color: green; }
 div { background-color: white, color: orange }
 ```
 
-This means it can condense the final output. Right now it doesn't substitute repeated rules, but that might be added in the future.
+This means it can condense the final output. And also that it's ok to `@apply` multiple `@expandable` classes to an element as any repeated attributes are just replaced.
 
-If you want multiple declarations to not be merged right now the only possibility is to have different entry points that produce plain css files and use them with regular `@import` rules on a final css file that isn't parsed by cssex. 
+If you want multiple declarations to not be merged right now the only possibility is to have different entry points that produce plain css files and use them with regular `@import` rules on a final css. 
 
 The final output always follows this format:
 
 ```
 @charset
 @imports
-**:root { variables }**
-**all regular selectors and their rules**
 @font-face
+**:root { variables }**
+@expandables
+**all regular selectors and their rules**
 @media
 @keyframes
+\n
 ```
 
 

--- a/lib/helpers/eex.ex
+++ b/lib/helpers/eex.ex
@@ -28,6 +28,7 @@ defmodule CSSEx.Helpers.EEX do
 
   def finish(rem, data, %{acc: eex_block, line: s_line}) do
     acc = IO.chardata_to_string(eex_block)
+
     final = eval_with_bindings(acc, data)
     new_final = :lists.flatten([to_charlist(final), ?$, 0, ?$, 0, ?$ | rem])
     :erlang.garbage_collect()
@@ -40,7 +41,8 @@ defmodule CSSEx.Helpers.EEX do
 
     {:ok, {new_final, new_data}}
   rescue
-    error -> {:error, add_error(%{data | line: s_line}, error_msg({:eex, error}))}
+    error ->
+      {:error, add_error(%{data | line: s_line}, error_msg({:eex, error}))}
   end
 
   def do_parse([], data, %{column: col, line: line}) do

--- a/lib/helpers/error.ex
+++ b/lib/helpers/error.ex
@@ -3,12 +3,14 @@ defmodule CSSEx.Helpers.Error do
 
   # this means that the error is being bubbled up
   def error_msg(%{valid?: false, error: error}), do: error
+  def error_msg({:error, error}), do: error_msg(error)
 
   def error_msg({:mismatched, char}), do: "mismatched #{char}"
 
   def error_msg({:not_declared, :var, val}), do: "variable #{val} was not declared"
   def error_msg({:not_declared, :val, val}), do: "assign #{val} was not declared"
   def error_msg({:not_declared, :function, name}), do: "function #{name} was not declared"
+  def error_msg({:not_declared, :expandable, name}), do: "@expandable #{name} was not declared"
   def error_msg({:unexpected, string}), do: "unexpected token: #{string}"
 
   def error_msg({:eex, error}), do: "parsing EEX tag: #{inspect(error)}"
@@ -43,4 +45,7 @@ defmodule CSSEx.Helpers.Error do
 
   def error_msg({:invalid_declaration, key, val}),
     do: "invalid declaration of css rule where key -> #{key} <- and value -> #{val} <-"
+
+  def error_msg({:invalid_expandable, name}),
+    do: "invalid @expandable selector #{name}"
 end

--- a/lib/helpers/expandable.ex
+++ b/lib/helpers/expandable.ex
@@ -1,0 +1,211 @@
+defmodule CSSEx.Helpers.Expandable do
+  import CSSEx.Parser, only: [close_current: 1, create_data_for_inner: 3]
+  import CSSEx.Helpers.Interpolations, only: [maybe_replace_val: 2]
+
+  @moduledoc false
+
+  def parse(rem, data) do
+    case CSSEx.Helpers.Shared.search_for(rem, '{') do
+      {:ok, {new_rem, selector}} ->
+        case validate_selector(selector, data) do
+          {:ok, validated} ->
+            case CSSEx.Helpers.Shared.block_search(new_rem, 1, []) do
+              {:ok, expandable_content} ->
+                inner_data =
+                  data
+                  |> set_base_selector(validated)
+                  |> create_data_for_inner(false, nil)
+
+                case CSSEx.Parser.parse(inner_data, new_rem) do
+                  {:finished,
+                   {%{column: n_col, line: n_line, media: media} = new_inner_data, new_rem_2}} ->
+                    new_data_2 =
+                      %{data | line: n_line, column: n_col, media: media}
+                      |> add(validated, new_inner_data, expandable_content)
+                      |> close_current()
+
+                    {:ok, {new_data_2, new_rem_2}}
+
+                  error ->
+                    error
+                end
+
+              error ->
+                error
+            end
+
+          error ->
+            error
+        end
+
+      error ->
+        error
+    end
+  end
+
+  def add(
+        %{expandables: existing, expandables_order_map: %{c: c} = eom} = data,
+        selector,
+        %{ets: ets, order_map: om, media: media} = inner_data,
+        expandable_content
+      ) do
+    taken_base =
+      case :ets.take(ets, [[selector]]) do
+        [{_, base}] ->
+          CSSEx.Helpers.Output.attributes_to_list(base)
+
+        _ ->
+          []
+      end
+
+    media_fixed =
+      Enum.reduce(media, [], fn {media_rule, {media_table, %{c: mc} = com}}, acc ->
+        all_internals =
+          Enum.reduce(0..mc, [], fn n, n_acc ->
+            case Map.get(com, n) do
+              nil ->
+                n_acc
+
+              m_selector ->
+                case :ets.lookup(media_table, m_selector) do
+                  [{[[^selector]], rules}] ->
+                    [n_acc, CSSEx.Helpers.Output.attributes_to_list(rules)]
+
+                  [{n_selector, rules}] ->
+                    [n_acc, n_selector, "{", CSSEx.Helpers.Output.attributes_to_list(rules), "}"]
+
+                  _ ->
+                    n_acc
+                end
+            end
+          end)
+
+        [acc, media_rule, "{", all_internals, "}"]
+      end)
+      |> IO.iodata_to_binary()
+
+    new_base =
+      taken_base
+      |> IO.iodata_to_binary()
+      |> to_charlist()
+
+    new_content =
+      ets
+      |> CSSEx.Helpers.Output.fold_attributes_table(om)
+      |> IO.iodata_to_binary()
+      |> to_charlist()
+
+    new_expandable =
+      expandable_content
+      |> IO.iodata_to_binary()
+
+    {:ok, new_expandable_fixed} =
+      CSSEx.Helpers.Interpolations.maybe_replace_val(new_expandable, inner_data)
+
+    new_expandables_om =
+      eom
+      |> Map.put(:c, c + 1)
+      |> Map.put(selector, c)
+      |> Map.put(c, selector)
+
+    case Map.get(existing, selector) do
+      nil ->
+        %{
+          data
+          | expandables:
+              Map.put(
+                existing,
+                selector,
+                {new_base, new_content, media_fixed, new_expandable_fixed, new_expandable}
+              ),
+            expandables_order_map: new_expandables_om
+        }
+
+      _ ->
+        # what to do if it has already been declared? overwrite and warn
+        # or keep old and warn ?
+        data
+    end
+  end
+
+  def validate_selector(selector, data) do
+    current_selector = String.trim(IO.chardata_to_string(selector))
+
+    case maybe_replace_val(current_selector, data) do
+      {:ok, replaced} ->
+        case String.split(replaced, ~r/,|\s/) do
+          [_] ->
+            {:ok, replaced}
+
+          _ ->
+            {:error, {:invalid_expandable, current_selector}}
+        end
+
+      error ->
+        {:error, {:invalid_expandable, current_selector}}
+    end
+  end
+
+  def set_base_selector(%{order_map: om} = data, validated) do
+    new_om =
+      data
+      |> Map.put([validated], 0)
+      |> Map.put(0, [validated])
+      |> Map.put(:c, 1)
+
+    %{data | order_map: %{c: 0}, current_chain: [validated]}
+  end
+
+  def make_apply(rem, %{expandables: expandables} = data) do
+    {:ok, {new_rem, identifiers}} = CSSEx.Helpers.Shared.search_for(rem, ';')
+
+    identifiers
+    |> IO.chardata_to_string()
+    |> String.split(~r/\s/, trim: true)
+    |> Enum.reduce_while({:ok, []}, fn identifier, {:ok, acc} ->
+      {expand?, id} =
+        case identifier do
+          "!" <> id -> {:as_is, id}
+          "?" <> id -> {:dynamic, id}
+          id -> {:at_parse, id}
+        end
+
+      selector = ".#{String.trim(id)}"
+
+      case Map.get(expandables, selector) do
+        nil ->
+          {:halt, {:error, {:not_declared, :expandable, selector}}}
+
+        {attrs, other_selectors, media, expandable_fixed, expandable} = all ->
+          to_add =
+            case expand? do
+              :as_is ->
+                case attrs do
+                  [] -> [media, "\n", other_selectors | []]
+                  _ -> [attrs, ?;, media | other_selectors]
+                end
+
+              :at_parse ->
+                expandable_fixed
+
+              :dynamic ->
+                expandable
+            end
+
+          {:cont, {:ok, [acc | to_add]}}
+      end
+    end)
+    |> case do
+      {:ok, expansion} ->
+        new_2 =
+          [expansion | new_rem]
+          |> IO.iodata_to_binary()
+          |> to_charlist
+
+        {:ok, new_2}
+
+      error ->
+        error
+    end
+  end
+end

--- a/lib/helpers/function.ex
+++ b/lib/helpers/function.ex
@@ -133,6 +133,7 @@ defmodule CSSEx.Helpers.Function do
 
   def finish_parse_call(%{functions: functions} = data, rem, acc) do
     fun_spec = IO.chardata_to_string(acc)
+
     {name, args} = extract_name_and_args(fun_spec, functions)
 
     case replace_args(args, data) do

--- a/lib/helpers/shared.ex
+++ b/lib/helpers/shared.ex
@@ -279,6 +279,21 @@ defmodule CSSEx.Helpers.Shared do
     search_args_split(rem, n, levels, [acc, char], full_acc)
   end
 
+  def search_for(content, target), do: search_for(content, target, [])
+
+  Enum.each(['{', ';'], fn chars ->
+    def search_for(unquote(chars) ++ rem, unquote(chars), acc), do: {:ok, {rem, acc}}
+  end)
+
+  def search_for([char | rem], chars, acc), do: search_for(rem, chars, [acc | [char]])
+  def search_for([], _, acc), do: {:error, {[], acc}}
+
+  def block_search([125 | rem], 1, acc), do: {:ok, acc}
+  def block_search([125 | rem], n, acc), do: block_search(rem, n - 1, [acc, "}"])
+  def block_search([123 | rem], n, acc), do: block_search(rem, n + 1, [acc, "{"])
+  def block_search([char | rem], n, acc), do: block_search(rem, n, [acc, char])
+  def block_search([], _, _acc), do: {:error, {:block_search, :no_closing}}
+
   def valid_attribute_kv?(key, val)
       when is_binary(key) and
              is_binary(val) and

--- a/test/error_test.exs
+++ b/test/error_test.exs
@@ -118,7 +118,6 @@ defmodule CSSEx.Error.Test do
 
     assert {:error, %Parser{error: error}} = Parser.parse("div{:color:}")
 
-    assert error =~
-             "invalid declaration of css rule where key ->  <- and value -> color: <-\" :: l:1 c:4"
+    assert error =~ "\"unexpected token: color\" :: l:1 c:4"
   end
 end

--- a/test/expandable_apply_test.exs
+++ b/test/expandable_apply_test.exs
@@ -1,0 +1,167 @@
+defmodule CSSEx.ExpandableApply.Test do
+  use ExUnit.Case, async: true
+  alias CSSEx.Parser
+
+  test "expandable and apply 1" do
+    assert {:ok, _,
+            ".expandable{color:red;width:100px}.expandable.test{border:2px solid red}.exp_2{color:orange}.class-1{background-color:blue;color:red;height:50px;width:100px}.class-1.test{border:2px solid red}.class-2{color:green}.class-2 .class-inner{color:orange;width:200px}.class-2 .class-inner .expandable.test{border:2px solid red}\n"} =
+             Parser.parse("""
+             $!color red;
+             @expandable .expandable {
+               color: <$color$>;
+               width: 100px;
+               &.test {
+                 border: 2px solid <$color$>;
+               }
+             }
+             .class-1 {
+               background-color: blue;
+               @apply expandable;
+               height: 50px;
+             }
+             @expandable .exp_2 {
+               color: orange;
+             }
+             $!color purple;
+             .class-2 {
+               color: green;
+               .class-inner {
+                 color: magenta;
+                 @apply !expandable exp_2;
+                 width: 200px;
+             }
+             }
+             """)
+  end
+
+  test "expandable and apply 2" do
+    assert {:ok, _,
+            ".expandable{color:red;width:100px}.expandable.test{border:2px solid red}.exp_2{color:orange;font-size:12px}.class-1{background-color:blue;color:red;height:50px;width:100px}.class-1.test{border:2px solid red}.class-2{color:green}.class-2 .class-inner{color:purple;font-size:12px;width:200px}.class-2 .class-inner.test{border:2px solid purple}\n"} =
+             Parser.parse("""
+             $!color red;
+             @expandable .expandable {
+               color: <$color$>;
+               width: 100px;
+               &.test {
+                 border: 2px solid <$color$>;
+               }
+             }
+             .class-1 {
+               background-color: blue;
+               @apply expandable;
+               height: 50px;
+             }
+             @expandable .exp_2 {
+               color: orange;
+               font-size: 12px;
+             }
+             $!color purple;
+             .class-2 {
+               color: green;
+               .class-inner {
+                 color: magenta;
+                 @apply exp_2 ?expandable;
+                 width: 200px;
+             }
+             }
+             """)
+  end
+
+  test "expandable and apply 3" do
+    assert {:ok, _,
+            ".hoverable{color:red}.hoverable:hover{color:rgba(204,0,0,1.0)}container .hoverable{background-color:black}.class-1{color:red}.class-1:hover{color:rgba(204,0,0,1.0)}container .class-1{background-color:black}.class-2{color:red}.class-2 .hoverable:hover{color:rgba(204,0,0,1.0)}.class-2 container .hoverable{background-color:black}.class-3{color:blue}.class-3:hover{color:rgba(0,204,0,1.0)}container .class-3{background-color:black}.class-4{color:red}.class-4:hover{color:rgba(204,0,0,1.0)}container .class-4{background-color:black}\n"} =
+             Parser.parse("""
+             $!color red;
+
+             @expandable .hoverable {
+               color: <$color$>;
+               &:hover {
+                 color: @fn::darken(<$color$>, 10);
+               }
+               container& {
+                 background-color: black;
+               }
+             }
+             .class-1 {
+               @apply hoverable;
+             }
+             $!color blue;
+             .class-2 {
+               @apply !hoverable;
+             }
+
+             .class-3 {
+               @apply ?hoverable;
+             }
+
+             .class-4 {
+               @apply hoverable;
+             }
+             """)
+  end
+
+  test "expandable and eex blocks" do
+    assert {:ok, _,
+            ".class-2{color:white}@media screen and (max-width:768px){.test{color:red;font-size:12px}.class-1{color:red;font-size:12px}.class-3{color:blue;font-size:12px}.class-2{color:red;font-size:12px}}@media screen and (min-width:1200px) and (max-width:1440px){.test{color:red;font-size:36px}.class-1{color:red;font-size:36px}.class-3{color:blue;font-size:36px}.class-2{color:red;font-size:36px}}@media screen and (min-width:1440px) and (max-width){.test{color:red;font-size:40px}.class-1{color:red;font-size:40px}.class-3{color:blue;font-size:40px}.class-2{color:red;font-size:40px}}@media screen and (min-width:768px) and (max-width:992px){.test{color:red;font-size:18px}.class-1{color:red;font-size:18px}.class-3{color:blue;font-size:18px}.class-2{color:red;font-size:18px}}@media screen and (min-width:992px) and (max-width:1200px){.test{color:red;font-size:24px}.class-1{color:red;font-size:24px}.class-3{color:blue;font-size:24px}.class-2{color:red;font-size:24px}}\n"} =
+             Parser.parse("""
+             $!color red;
+             @!screen_breakpoints [
+             sm: "0px",
+             md: "768px",
+             lg: "992px",
+             xl: "1200px",
+             xxl: "1440px",
+             ];
+
+             @!sizes %{
+             sm: 12,
+             md: 18,
+             lg: 24,
+             xl: 36,
+             xxl: 40
+             };
+
+             @fn breakpoint_min_max(min_bp, max_bp, breakpoints) ->
+             min_bp = String.to_existing_atom(min_bp)
+             max_bp = String.to_existing_atom(max_bp)
+             keys = Keyword.keys(breakpoints)
+             min_index = Enum.find_index(keys, fn(x) -> x == min_bp end)
+             min = Keyword.get(breakpoints, min_bp)
+
+             max = case max_bp && max_bp != min_bp do
+             true -> Keyword.get(breakpoints, max_bp)
+             false -> Keyword.get(breakpoints, Enum.at(keys, min_index + 1))
+             end
+
+             %CSSEx.Unit{value: val} = CSSEx.Unit.new_unit(min)
+             min_text = if(val > 0, do: " and (min-width: \#{min})", else: "")
+
+             "@media screen\#{min_text} and (max-width: \#{max}) { \#{ctx_content} }"  
+             end;
+
+             @expandable .test {
+             <%=  for {k, _width} <- @screen_breakpoints, reduce: "" do
+               acc ->
+                 acc <> "@fn::breakpoint_min_max(\#{k}, false, @::screen_breakpoints,
+                    font-size: \#{Map.get(@sizes, k)}px;
+             color: <$color$>
+                 )"
+             end %>
+             }
+
+             .class-1 {
+               @apply test;
+             }
+             $!color blue;
+
+             .class-3 {
+               @apply ?test;
+             }
+
+             .class-2 {
+               @apply !test;
+               color: white;
+             }
+             """)
+  end
+end

--- a/test/file_test.exs
+++ b/test/file_test.exs
@@ -42,7 +42,7 @@ defmodule CSSEx.File.Test do
     {:ok, %{target_originals: target_originals, non_existing: non_existing_path}}
   end
 
-  @full_final_css ".test_1{background-color:#000000;color:#ffffff}.test_2{background-color:#ffffff;color:#000000}div{color:black;color:white;background-color:red}div:hover{cursor:pointer;background-color:green;color:purple}\n"
+  @full_final_css ".test_1{background-color:#000000;color:#ffffff}.test_2{background-color:#ffffff;color:#000000}div{background-color:red;color:white}div:hover{background-color:green;color:purple;cursor:pointer}\n"
 
   test "parses a file", %{target_originals: base_path} do
     final_path = Path.join([base_path, "test_1.cssex"])

--- a/test/function_test.exs
+++ b/test/function_test.exs
@@ -28,7 +28,7 @@ defmodule CSSEx.Function.Test do
     assert {
              :ok,
              _,
-             ".test{color:hsla(0,100%,60%,1.0);color:hsla(300,7%,15%,1.0)}\n"
+             ".test{color:hsla(300,7%,15%,1.0)}\n"
            } = Parser.parse(@basic)
   end
 

--- a/test/keyframes_test.exs
+++ b/test/keyframes_test.exs
@@ -23,7 +23,7 @@ defmodule CSSEx.Keyframes.Test do
 
   test "basic keyframes test" do
     assert {:ok, _,
-            ".test{color:red;font-family:Arial, sans-serif}div{color:blue}@keyframes mysummer{0%{top:0px;left:20px}100%{left:0px;top:20px}}@keyframes mywinter{0%{top:0px;left:20px}100%{left:0px;top:20px}}\n"} =
+            ".test{color:red;font-family:Arial, sans-serif}div{color:blue}@keyframes mysummer{0%{left:20px;top:0px}100%{left:0px;top:20px}}@keyframes mywinter{0%{left:20px;top:0px}100%{left:0px;top:20px}}\n"} =
              Parser.parse(@basic)
   end
 end

--- a/test/media_test.exs
+++ b/test/media_test.exs
@@ -23,7 +23,7 @@ defmodule CSSEx.Media.Test do
              """)
 
     assert parsed =~
-             "@media screen and (max-width:600px){.test div.example{display:none}.test{font-family:Arial;background-color:black}}\n"
+             "@media screen and (max-width:600px){.test div.example{display:none}.test{background-color:black;font-family:Arial}}\n"
 
     assert parsed =~ ".test{color:red}"
   end

--- a/test/nesting_test.exs
+++ b/test/nesting_test.exs
@@ -39,7 +39,7 @@ defmodule CSSEx.Nesting.Test do
 
     assert parsed =~ ".div_1{color:red}"
     assert parsed =~ ".div_1 .div_1_b,.div_1 .div_1_a{color:blue}"
-    assert parsed =~ ".div_1.div_2_a{width:100%;padding:5px}"
+    assert parsed =~ ".div_1.div_2_a{padding:5px;width:100%}"
     assert parsed =~ ".div_1.div_2_a.div_2_a_a,.div_1 .div_2_b.div_2_a_a{height:100%}"
     assert parsed =~ ".div_1.div_2_a.div_2_a_a .inner-inner{display:block}"
     assert parsed =~ ".div_1.div_3_b,.div_1 .div_1_a{margin:10px}"


### PR DESCRIPTION
- Remove duplication of attributes when coalescing selectors
Given that `@apply` could get completely out of hand with multiple repeated attributes it just forced me to do it now.

- Added @expandable and @apply
Very nice, great success.

- Fixed bug with nested parsers when the current chain wasn't set
This showed up when doing nested @media inside @expandables but could show in other places when doing certain combinations of nesting, basically it was missing a function head for when the current chain was an empty list but the split chain was not.