### PR TITLE
Make <$ ... $> regex non greedy and scope with @? and $? correction

### DIFF
--- a/lib/helpers/assigns.ex
+++ b/lib/helpers/assigns.ex
@@ -65,7 +65,7 @@ defmodule CSSEx.Helpers.Assigns do
     case Map.get(assigns, key) do
       nil ->
         case Map.get(local_assigns, key) do
-          nil -> %{data | local_assigns: Map.put(local_assigns, key, val)}
+          nil -> %{data | assigns: Map.put(assigns, key, val)}
           _ -> data
         end
 

--- a/lib/helpers/interpolations.ex
+++ b/lib/helpers/interpolations.ex
@@ -5,8 +5,8 @@ defmodule CSSEx.Helpers.Interpolations do
   # in either the local_scope (first match) or the global scope (second match)
   alias CSSEx.Helpers.EEX, as: HEEX
 
-  @regex_val ~r/(?<interpolation><\$.+\$>)|(?<eex_l><%=.+?end\s?%>)|(?<eex_s><%=.+?%>)/u
-  @regex_arg ~r/(?<interpolation><\$.+\$>)|<%=\s?(?<eex_l>.+?)\?end\s+?%>|<%=(?<eex_s>.+?)%>/u
+  @regex_val ~r/(?<interpolation><\$.+?\$>)|(?<eex_l><%=.+?end\s?%>)|(?<eex_s><%=.+?%>)/u
+  @regex_arg ~r/(?<interpolation><\$.+?\$>)|<%=\s?(?<eex_l>.+?)\?end\s+?%>|<%=(?<eex_s>.+?)%>/u
 
   def maybe_replace_val(<<"$::", var_name::binary>>, %{local_scope: ls})
       when is_map_key(ls, var_name),

--- a/lib/parser.ex
+++ b/lib/parser.ex
@@ -1319,7 +1319,7 @@ defmodule CSSEx.Parser do
     case Map.get(scope, key) do
       nil ->
         case Map.get(local_scope, key) do
-          nil -> %{data | local_scope: Map.put(local_scope, key, val)}
+          nil -> %{data | scope: Map.put(scope, key, val)}
           _ -> data
         end
 

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -75,12 +75,14 @@ defmodule CSSEx.Parser.Test do
       "interpolation works in attributes",
       """
       $!test px;
-
+      $!width-a 10px;
+      $!width-b 20px;
       div {
         border: 2<$test$> solid red;
+        width: calc(100% - <$width-a$> - <$width-b$>);
       }
       """,
-      "div{border:2px solid red}\n"
+      "div{border:2px solid red;width:calc(100% - 10px - 20px)}\n"
     },
     {
       "interpolation works in rules and other non-attributes",


### PR DESCRIPTION
Removed greediness for the regex matching <$ ... $> as multiple of them, e.g. in a calc() statement, would be wrongly parsed as a single one.

Made $? and @? both set the global instead of local scope if neither a global or local with that name is set - this is so that if you load a partial stylesheet that sets some *? they will be set globally from then on.