### PR TITLE
Watcher & Parser File error handling on missing @include improvement/fixes

### DIFF
--- a/lib/cssex.ex
+++ b/lib/cssex.ex
@@ -253,7 +253,13 @@ defmodule CSSEx do
         _state,
         %{dependency_graph: d_g} = data
       ) do
-    new_d_g = clean_up_deps(d_g, original_file, [error_file | dependencies])
+    to_clean_up =
+      case error_file do
+        nil -> dependencies
+        _ -> [error_file | dependencies]
+      end
+
+    new_d_g = clean_up_deps(d_g, original_file, to_clean_up)
 
     {:keep_state, %{data | dependency_graph: new_d_g},
      [{:next_event, :internal, :synch_watchers}]}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Cssex.MixProject do
   def project do
     [
       app: :cssex,
-      version: "0.6.5",
+      version: "0.6.6",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Paths for includes were being retrieved relatively to the entry pointfile, so if a file included another file and that file included another, this include would need to reference the relative path relative to the entry, while it's more intuitive to be relative to the file including it

When a missing file in an @include statement occurred the watcher would crash as the parser ctx was being returned with a file value of nil, now the parser passes on the dependency tree down to newly started parsers and in case a file misses it includes itself as the file this allows the watcher to setup correct watching for that file and not crash