### PR TITLE
fix chain bork when reversing unprefixed chains

### DIFF
--- a/lib/helpers/eex.ex
+++ b/lib/helpers/eex.ex
@@ -28,7 +28,6 @@ defmodule CSSEx.Helpers.EEX do
 
   def finish(rem, data, %{acc: eex_block, line: s_line}) do
     acc = IO.chardata_to_string(eex_block)
-
     final = eval_with_bindings(acc, data)
     new_final = :lists.flatten([to_charlist(final), ?$, 0, ?$, 0, ?$ | rem])
     :erlang.garbage_collect()

--- a/lib/helpers/expandable.ex
+++ b/lib/helpers/expandable.ex
@@ -191,7 +191,7 @@ defmodule CSSEx.Helpers.Expandable do
     |> case do
       {:ok, expansion} ->
         new_2 =
-          [expansion | new_rem]
+          [expansion | [?$, 0, ?$, 0, ?$ | new_rem]]
           |> IO.iodata_to_binary()
           |> to_charlist
 

--- a/lib/helpers/shared.ex
+++ b/lib/helpers/shared.ex
@@ -47,15 +47,15 @@ defmodule CSSEx.Helpers.Shared do
   def remove_last_from_chain(%{current_chain: [_ | _] = chain, prefix: prefix} = data) do
     [_ | new_chain] = :lists.reverse(chain)
 
-    new_chain =
+    new_chain_for_merge =
       case prefix do
         nil -> :lists.reverse(new_chain)
         _ -> prefix ++ :lists.reverse(new_chain)
       end
 
-    case split_chains(new_chain) do
+    case split_chains(new_chain_for_merge) do
       [_ | _] = splitted ->
-        %{data | current_chain: new_chain, split_chain: merge_split(splitted)}
+        %{data | current_chain: :lists.reverse(new_chain), split_chain: merge_split(splitted)}
 
       {:error, error} ->
         CSSEx.Parser.add_error(data, Error.error_msg(error))

--- a/lib/parser.ex
+++ b/lib/parser.ex
@@ -313,7 +313,7 @@ defmodule CSSEx.Parser do
     new_data =
       data
       |> open_current(:function_call)
-      |> inc_col(2)
+      |> inc_col(5)
 
     case CSSEx.Helpers.Function.parse_call(new_data, rem) do
       {:ok, {new_data_2, new_rem}} ->
@@ -1110,6 +1110,7 @@ defmodule CSSEx.Parser do
           |> add_to_dependencies(file)
           |> merge_dependencies(new_inner_data)
 
+        :erlang.garbage_collect()
         {:next_state, {:parse, :next}, new_data, [{:next_event, :internal, {:parse, rem}}]}
 
       # TODO error needs to stop correctly


### PR DESCRIPTION
When parsing inner contexts (@include, @media, etc) when a prefix was present it would include the prefix on the new chain, whereas it should only be included on the split chain. This was only visible with multiple nests inside a new parser context, since at the top level context there wouldn't be a prefix, and if the @includes only had 1 level declarations the prefix wouldn't be merged back. This fixes it.

Also corrected the col increase for the `@fn::` match, and added a no_count marker for the expansion of an @expandable 