### PR TITLE
Temp fix for attributes with a colon that might split into more than …

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Cssex.MixProject do
   def project do
     [
       app: :cssex,
-      version: "0.6.8",
+      version: "0.6.9",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
…one - this only takes care of `src` rules but TODO proper fix 