### PR TITLE
Bump elixir version to 1.13 so we can change IO.read(device, :all) to :eof

### DIFF
--- a/.github/workflows/elixir_test.yml
+++ b/.github/workflows/elixir_test.yml
@@ -22,7 +22,7 @@ jobs:
         elixir-version: '1.18.1'
         otp-version: '27.2.0'
     - name: Restore dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: deps
         key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}

--- a/.github/workflows/elixir_test.yml
+++ b/.github/workflows/elixir_test.yml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install inotify-tools
       run: sudo apt install inotify-tools
     - name: Set up Elixir
       uses: erlef/setup-beam@v1
       with:
-        elixir-version: '1.15.7'
-        otp-version: '26.1.2'
+        elixir-version: '1.18.1'
+        otp-version: '27.2.0'
     - name: Restore dependencies cache
       uses: actions/cache@v2
       with:

--- a/lib/helpers/output.ex
+++ b/lib/helpers/output.ex
@@ -462,8 +462,6 @@ defmodule CSSEx.Helpers.Output do
           {:cont, :ok}
 
         folded ->
-          IO.inspect(folded: folded, rule: rule)
-
           case IO.binwrite(to_file, [
                  rule,
                  open_curly(opts),

--- a/lib/parser.ex
+++ b/lib/parser.ex
@@ -306,7 +306,7 @@ defmodule CSSEx.Parser do
             }
 
             {:next_state, {:parse, :next}, new_data,
-             [{:next_event, :internal, {:parse, IO.read(device, :all)}}]}
+             [{:next_event, :internal, {:parse, IO.read(device, :eof)}}]}
 
           {:error, :enoent} ->
             file_errored =
@@ -1618,7 +1618,7 @@ defmodule CSSEx.Parser do
   end
 
   def validate_import(%{first_rule: false} = data),
-    do: add_warning(data, warning_msg(:import_declaration))
+    do: add_warning(data, warning_msg(:import_position))
 
   @doc false
   def first_rule(%{first_rule: false} = data), do: data

--- a/mix.exs
+++ b/mix.exs
@@ -4,8 +4,8 @@ defmodule Cssex.MixProject do
   def project do
     [
       app: :cssex,
-      version: "1.0.1",
-      elixir: "~> 1.11",
+      version: "1.0.2",
+      elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       name: "CSSEx",

--- a/test/pretty_printing_test.exs
+++ b/test/pretty_printing_test.exs
@@ -75,9 +75,6 @@ defmodule CSSEx.PrettyPrinting.Test do
   end
 
   test "parsing content with pretty print without file" do
-    assert output =
-             Parser.parse(@source, pretty_print?: true)
-
     assert {:ok, _, @output} =
              Parser.parse(@source, pretty_print?: true)
   end

--- a/test/task_test.exs
+++ b/test/task_test.exs
@@ -141,7 +141,12 @@ defmodule CSSEx.Task.Test do
     dest_path: dest_path
   } do
     assert capture_log(fn ->
-             Mix.Tasks.Cssex.Parser.run(["--e", "#{base_without}=#{dest_without}", "--a", "cssex"])
+             Mix.Tasks.Cssex.Parser.run([
+               "--e",
+               "#{base_without}=#{dest_without}",
+               "--a",
+               "cssex"
+             ])
            end) =~ "PROCESSED :: #{base_path} into \"#{dest_path}"
 
     assert {:ok, "div.test{color:red}\n"} = File.read(dest_path)


### PR DESCRIPTION
Updating elixir version in some older projects flooded the shell with deprecation warnings so this fixes that by changing it to the future format. The oldest version to support :eof (although it wasn't deprecating :all then) was 1.13, so that has to be bumped too.

Additionally fixed a mismatch on the :atom being passed to the error message generator. Don't think anyone would ever run into it, since you usually do all imports at the top of the file, but fixed anyway.

Removed IO.inspect and debugging assignment in a test to tidy up.

File Formatting Issue

Updated github action to use cache v4 and both elixir and erlang versions used on the ci